### PR TITLE
Adding extensions for rbac checks

### DIFF
--- a/extensions/kubeapi/rbac/list.go
+++ b/extensions/kubeapi/rbac/list.go
@@ -32,7 +32,6 @@ func ListRoleBindings(client *rancher.Client, clusterName, namespace string, lis
 
 		rbList.Items = append(rbList.Items, *rb)
 	}
-
 	return rbList, nil
 }
 
@@ -55,7 +54,6 @@ func ListClusterRoleBindings(client *rancher.Client, clusterName string, listOpt
 		if err != nil {
 			return nil, err
 		}
-
 		crbList.Items = append(crbList.Items, *crb)
 	}
 
@@ -81,7 +79,6 @@ func ListGlobalRoleBindings(client *rancher.Client, listOpt metav1.ListOptions) 
 		if err != nil {
 			return nil, err
 		}
-
 		grbList.Items = append(grbList.Items, *grb)
 	}
 
@@ -107,7 +104,6 @@ func ListClusterRoleTemplateBindings(client *rancher.Client, listOpt metav1.List
 		if err != nil {
 			return nil, err
 		}
-
 		crtbList.Items = append(crtbList.Items, *crtb)
 	}
 
@@ -133,7 +129,6 @@ func ListGlobalRoles(client *rancher.Client, listOpt metav1.ListOptions) (*v3.Gl
 		if err != nil {
 			return nil, err
 		}
-
 		grList.Items = append(grList.Items, *gr)
 	}
 
@@ -159,9 +154,34 @@ func ListRoleTemplates(client *rancher.Client, listOpt metav1.ListOptions) (*v3.
 		if err != nil {
 			return nil, err
 		}
-
 		rtList.Items = append(rtList.Items, *rt)
 	}
 
 	return rtList, nil
 }
+
+// ListProjectRoleTemplateBindings is a helper function that uses the dynamic client to list projectroletemplatebindings from local cluster.
+func ListProjectRoleTemplateBindings(client *rancher.Client, listOpt metav1.ListOptions) (*v3.ProjectRoleTemplateBindingList, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(LocalCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredList, err := dynamicClient.Resource(ProjectRoleTemplateBindingGroupVersionResource).Namespace("").List(context.TODO(), listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	prtbList := new(v3.ProjectRoleTemplateBindingList)
+	for _, unstructuredPRTB := range unstructuredList.Items {
+		prtb := &v3.ProjectRoleTemplateBinding{}
+		err := scheme.Scheme.Convert(&unstructuredPRTB, prtb, unstructuredPRTB.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		prtbList.Items = append(prtbList.Items, *prtb)
+	}
+	return prtbList, nil
+}
+

--- a/extensions/rbac/config.go
+++ b/extensions/rbac/config.go
@@ -5,7 +5,7 @@ const (
 )
 
 type Config struct {
-	Role     string `json:"role" yaml:"role"`
+	Role     Role `json:"role" yaml:"role"`
 	Username string `json:"username" yaml:"username"`
 	Password string `json:"password" yaml:"password"`
 }

--- a/extensions/rbac/rbac.go
+++ b/extensions/rbac/rbac.go
@@ -1,0 +1,41 @@
+package rbac
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/users"
+)
+
+type Role string
+
+const (
+	RestrictedAdmin           Role = "restricted-admin"
+	StandardUser              Role = "user"
+	ClusterOwner              Role = "cluster-owner"
+	ClusterMember             Role = "cluster-member"
+	ProjectOwner              Role = "project-owner"
+	ProjectMember             Role = "project-member"
+	CreateNS                  Role = "create-ns"
+	ReadOnly                  Role = "read-only"
+	CustomManageProjectMember Role = "projectroletemplatebindings-manage"
+	ActiveStatus                   = "active"
+	ForbiddenError                 = "403 Forbidden"
+	DefaultNamespace               = "fleet-default"
+)
+
+func (r Role) String() string {
+	return string(r)
+}
+
+// SetupUser is a helper to create a global role and a client for the user.
+func SetupUser(client *rancher.Client, globalRole string) (user *management.User, userClient *rancher.Client, err error) {
+	user, err = users.CreateUserWithRole(client, users.UserConfig(), globalRole)
+	if err != nil {
+		return
+	}
+	userClient, err = client.AsUser(user)
+	if err != nil {
+		return
+	}
+	return
+}

--- a/extensions/rbac/verify.go
+++ b/extensions/rbac/verify.go
@@ -3,7 +3,6 @@ package rbac
 import (
 	"fmt"
 	"net/url"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -22,22 +21,6 @@ import (
 	coreV1 "k8s.io/api/core/v1"
 )
 
-const (
-	roleOwner                     = "cluster-owner"
-	roleMember                    = "cluster-member"
-	roleProjectOwner              = "project-owner"
-	roleProjectMember             = "project-member"
-	roleCustomManageProjectMember = "projectroletemplatebindings-manage"
-	roleCustomCreateNS            = "create-ns"
-	roleProjectReadOnly           = "read-only"
-	restrictedAdmin               = "restricted-admin"
-	standardUser                  = "user"
-	activeStatus                  = "active"
-	forbiddenError                = "403 Forbidden"
-)
-
-var rgx = regexp.MustCompile(`\[(.*?)\]`)
-
 // VerifyGlobalRoleBindingsForUser validates that a global role bindings is created for a user when the user is created
 func VerifyGlobalRoleBindingsForUser(t *testing.T, user *management.User, adminClient *rancher.Client) {
 	query := url.Values{"filter": {"userName=" + user.ID}}
@@ -47,7 +30,7 @@ func VerifyGlobalRoleBindingsForUser(t *testing.T, user *management.User, adminC
 }
 
 // VerifyUserCanListCluster validates a user with the required global permissions are able to/not able to list the clusters in rancher server
-func VerifyUserCanListCluster(t *testing.T, client, standardClient *rancher.Client, clusterID, role string) {
+func VerifyUserCanListCluster(t *testing.T, client, standardClient *rancher.Client, clusterID string, role Role) {
 	clusterList, err := standardClient.Steve.SteveType(clusters.ProvisioningSteveResourceType).ListAll(nil)
 	require.NoError(t, err)
 
@@ -55,7 +38,7 @@ func VerifyUserCanListCluster(t *testing.T, client, standardClient *rancher.Clie
 	err = v1.ConvertToK8sType(clusterList.Data[0].Status, clusterStatus)
 	require.NoError(t, err)
 
-	if role == restrictedAdmin {
+	if role == RestrictedAdmin {
 		adminClusterList, err := client.Steve.SteveType(clusters.ProvisioningSteveResourceType).ListAll(nil)
 		require.NoError(t, err)
 		assert.Equal(t, (len(adminClusterList.Data) - 1), len(clusterList.Data))
@@ -67,44 +50,41 @@ func VerifyUserCanListCluster(t *testing.T, client, standardClient *rancher.Clie
 }
 
 // VerifyUserCanListProject validates a user with the required cluster permissions are able/not able to list projects in the downstream cluster
-func VerifyUserCanListProject(t *testing.T, client, standardClient *rancher.Client, clusterID, role, adminProjectName string) {
+func VerifyUserCanListProject(t *testing.T, client, standardClient *rancher.Client, clusterID, adminProjectName string, role Role) {
 	projectListNonAdmin, err := projects.ListProjectNames(standardClient, clusterID)
 	require.NoError(t, err)
 	projectListAdmin, err := projects.ListProjectNames(client, clusterID)
 	require.NoError(t, err)
 
 	switch role {
-	case roleOwner, restrictedAdmin:
+	case ClusterOwner, RestrictedAdmin:
 		assert.Equal(t, len(projectListAdmin), len(projectListNonAdmin))
 		assert.Equal(t, projectListAdmin, projectListNonAdmin)
-	case roleMember:
+	case ClusterMember:
 		assert.Equal(t, 0, len(projectListNonAdmin))
-	case roleProjectOwner, roleProjectMember:
+	case ProjectOwner, ProjectMember:
 		assert.Equal(t, 1, len(projectListNonAdmin))
 		assert.Equal(t, adminProjectName, projectListNonAdmin[0])
 	}
 }
 
 // VerifyUserCanCreateProjects validates a user with the required cluster permissions are able/not able to create projects in the downstream cluster
-func VerifyUserCanCreateProjects(t *testing.T, client, standardClient *rancher.Client, clusterID, role string) {
+func VerifyUserCanCreateProjects(t *testing.T, client, standardClient *rancher.Client, clusterID string, role Role) {
 	memberProject, err := standardClient.Management.Project.Create(projects.NewProjectConfig(clusterID))
 	switch role {
-	case roleOwner, roleMember, restrictedAdmin:
+	case ClusterOwner, ClusterMember, RestrictedAdmin:
 		require.NoError(t, err)
 		log.Info("Created project as a ", role, " is ", memberProject.Name)
 		actualStatus := fmt.Sprintf("%v", memberProject.State)
-		assert.Equal(t, activeStatus, strings.ToLower(actualStatus))
-	case roleProjectOwner, roleProjectMember:
+		assert.Equal(t, ActiveStatus, strings.ToLower(actualStatus))
+	case ProjectOwner, ProjectMember:
 		require.Error(t, err)
-		errStatus := strings.Split(err.Error(), ".")[1]
-		errorMsg := rgx.FindStringSubmatch(errStatus)
-		assert.Equal(t, forbiddenError, errorMsg[1])
+		assert.Contains(t, err.Error(), ForbiddenError)
 	}
 }
 
 // VerifyUserCanCreateNamespace validates a user with the required cluster permissions are able/not able to create namespaces in the project they do not own
-func VerifyUserCanCreateNamespace(t *testing.T, client, standardClient *rancher.Client, project *management.Project, clusterID, role string) {
-	var checkErr error
+func VerifyUserCanCreateNamespace(t *testing.T, client, standardClient *rancher.Client, project *management.Project, clusterID string, role Role) {
 	namespaceName := namegen.AppendRandomString("testns-")
 	standardClient, err := standardClient.ReLogin()
 	require.NoError(t, err)
@@ -112,7 +92,7 @@ func VerifyUserCanCreateNamespace(t *testing.T, client, standardClient *rancher.
 	createdNamespace, checkErr := namespaces.CreateNamespace(standardClient, namespaceName, "{}", map[string]string{}, map[string]string{}, project)
 
 	switch role {
-	case roleOwner, roleProjectOwner, roleProjectMember, restrictedAdmin:
+	case ClusterOwner, ProjectOwner, ProjectMember, RestrictedAdmin:
 		require.NoError(t, checkErr)
 		log.Info("Created a namespace as role ", role, createdNamespace.Name)
 		assert.Equal(t, namespaceName, createdNamespace.Name)
@@ -121,17 +101,15 @@ func VerifyUserCanCreateNamespace(t *testing.T, client, standardClient *rancher.
 		err = v1.ConvertToK8sType(createdNamespace.Status, namespaceStatus)
 		require.NoError(t, err)
 		actualStatus := fmt.Sprintf("%v", namespaceStatus.Phase)
-		assert.Equal(t, activeStatus, strings.ToLower(actualStatus))
-	case roleMember:
+		assert.Equal(t, ActiveStatus, strings.ToLower(actualStatus))
+	case ClusterMember:
 		require.Error(t, checkErr)
-		errStatus := strings.Split(checkErr.Error(), ".")[1]
-		errorMsg := rgx.FindStringSubmatch(errStatus)
-		assert.Equal(t, forbiddenError, errorMsg[1])
+		assert.Contains(t, checkErr.Error(), ForbiddenError)
 	}
 }
 
 // VerifyUserCanListNamespace validates a user with the required cluster permissions are able/not able to list namespaces in the project they do not own
-func VerifyUserCanListNamespace(t *testing.T, client, standardClient *rancher.Client, project *management.Project, clusterID, role string) {
+func VerifyUserCanListNamespace(t *testing.T, client, standardClient *rancher.Client, project *management.Project, clusterID string, role Role) {
 	log.Info("Validating if ", role, " can lists all namespaces in a cluster.")
 
 	steveAdminClient, err := client.Steve.ProxyDownstream(clusterID)
@@ -148,14 +126,14 @@ func VerifyUserCanListNamespace(t *testing.T, client, standardClient *rancher.Cl
 	sortedNamespaceListNonAdmin := namespaceListNonAdmin.Names()
 
 	switch role {
-	case roleOwner, restrictedAdmin:
+	case ClusterOwner, RestrictedAdmin:
 		require.NoError(t, err)
 		assert.Equal(t, len(sortedNamespaceListAdmin), len(sortedNamespaceListNonAdmin))
 		assert.Equal(t, sortedNamespaceListAdmin, sortedNamespaceListNonAdmin)
-	case roleMember:
+	case ClusterMember:
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(sortedNamespaceListNonAdmin))
-	case roleProjectOwner, roleProjectMember:
+	case ProjectOwner, ProjectMember:
 		require.NoError(t, err)
 		assert.NotEqual(t, len(sortedNamespaceListAdmin), len(sortedNamespaceListNonAdmin))
 		assert.Equal(t, 1, len(sortedNamespaceListNonAdmin))
@@ -163,7 +141,7 @@ func VerifyUserCanListNamespace(t *testing.T, client, standardClient *rancher.Cl
 }
 
 // VerifyUserCanDeleteNamespace validates a user with the required cluster permissions are able/not able to delete namespaces in the project they do not own
-func VerifyUserCanDeleteNamespace(t *testing.T, client, standardClient *rancher.Client, project *management.Project, clusterID, role string) {
+func VerifyUserCanDeleteNamespace(t *testing.T, client, standardClient *rancher.Client, project *management.Project, clusterID string, role Role) {
 
 	log.Info("Validating if ", role, " cannot delete a namespace from a project they own.")
 	steveAdminClient, err := client.Steve.ProxyDownstream(clusterID)
@@ -180,70 +158,64 @@ func VerifyUserCanDeleteNamespace(t *testing.T, client, standardClient *rancher.
 	err = steveStandardClient.SteveType(namespaces.NamespaceSteveType).Delete(namespaceID)
 
 	switch role {
-	case roleOwner, roleProjectOwner, roleProjectMember, restrictedAdmin:
+	case ClusterOwner, ProjectOwner, ProjectMember, RestrictedAdmin:
 		require.NoError(t, err)
-	case roleMember:
+	case ClusterMember:
 		require.Error(t, err)
-		errMessage := strings.Split(err.Error(), ":")[0]
-		assert.Equal(t, "Resource type [namespace] can not be deleted", errMessage)
+		assert.Equal(t, err.Error, "Resource type [namespace] can not be deleted")
 	}
 }
 
 // VerifyUserCanAddClusterRoles validates a user with the required cluster permissions are able/not able to add other users in the cluster
-func VerifyUserCanAddClusterRoles(t *testing.T, client, memberClient *rancher.Client, cluster *management.Cluster, role string) {
-	additionalClusterUser, err := users.CreateUserWithRole(client, users.UserConfig(), standardUser)
+func VerifyUserCanAddClusterRoles(t *testing.T, client, memberClient *rancher.Client, cluster *management.Cluster, role Role) {
+	additionalClusterUser, err := users.CreateUserWithRole(client, users.UserConfig(), StandardUser.String())
 	require.NoError(t, err)
 
-	errUserRole := users.AddClusterRoleToUser(memberClient, cluster, additionalClusterUser, roleOwner, nil)
+	errUserRole := users.AddClusterRoleToUser(memberClient, cluster, additionalClusterUser, ClusterOwner.String(), nil)
 
 	switch role {
-	case roleProjectOwner, roleProjectMember:
+	case ProjectOwner, ProjectMember:
 		require.Error(t, errUserRole)
-		errStatus := strings.Split(errUserRole.Error(), ".")[1]
-		errorMsg := rgx.FindStringSubmatch(errStatus)
-		assert.Equal(t, forbiddenError, errorMsg[1])
-	case restrictedAdmin:
+		assert.Contains(t, errUserRole.Error(), ForbiddenError)
+	case RestrictedAdmin:
 		require.NoError(t, errUserRole)
 	}
-
 }
 
 // VerifyUserCanAddProjectRoles validates a user with the required cluster permissions are able/not able to add other users in a project on the downstream cluster
-func VerifyUserCanAddProjectRoles(t *testing.T, client *rancher.Client, project *management.Project, additionalUser *management.User, projectRole, clusterID, role string) {
+func VerifyUserCanAddProjectRoles(t *testing.T, client *rancher.Client, project *management.Project, additionalUser *management.User, projectRole, clusterID string, role Role) {
 
 	errUserRole := users.AddProjectMember(client, project, additionalUser, projectRole, nil)
 	projectList, errProjectList := projects.ListProjectNames(client, clusterID)
 	require.NoError(t, errProjectList)
 
 	switch role {
-	case roleProjectOwner:
+	case ProjectOwner:
 		require.NoError(t, errUserRole)
 		assert.Equal(t, 1, len(projectList))
 		assert.Equal(t, project.Name, projectList[0])
 
-	case restrictedAdmin:
+	case RestrictedAdmin:
 		require.NoError(t, errUserRole)
 		assert.Contains(t, projectList, project.Name)
 
-	case roleProjectMember:
+	case ProjectMember:
 		require.Error(t, errUserRole)
 	}
 
 }
 
 // VerifyUserCanDeleteProject validates a user with the required cluster/project permissions are able/not able to delete projects in the downstream cluster
-func VerifyUserCanDeleteProject(t *testing.T, client *rancher.Client, project *management.Project, role string) {
+func VerifyUserCanDeleteProject(t *testing.T, client *rancher.Client, project *management.Project, role Role) {
 	err := client.Management.Project.Delete(project)
 
 	switch role {
-	case roleOwner, roleProjectOwner:
+	case ClusterOwner, ProjectOwner:
 		require.NoError(t, err)
-	case roleMember:
+	case ClusterMember:
 		require.Error(t, err)
-		errStatus := strings.Split(err.Error(), ".")[1]
-		errorMsg := rgx.FindStringSubmatch(errStatus)
-		assert.Equal(t, forbiddenError, errorMsg[1])
-	case roleProjectMember:
+		assert.Contains(t, err.Error(), ForbiddenError)
+	case ProjectMember:
 		require.Error(t, err)
 	}
 }

--- a/extensions/settings/settings.go
+++ b/extensions/settings/settings.go
@@ -1,0 +1,6 @@
+package settings
+
+const (
+	ManagementSetting = "management.cattle.io.setting"
+	KubeConfigToken   = "kubeconfig-default-token-ttl-minutes"
+)

--- a/extensions/settings/update.go
+++ b/extensions/settings/update.go
@@ -1,0 +1,22 @@
+package settings
+
+import (
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+)
+
+// UpdateGlobalSettings is a helper function that uses the steve client to update a Global setting
+func UpdateGlobalSettings(steveclient *v1.Client, globalSetting *v1.SteveAPIObject, value string) (*v1.SteveAPIObject, error) {
+	updateSetting := &v3.Setting{}
+	err := v1.ConvertToK8sType(globalSetting.JSONResp, updateSetting)
+	if err != nil {
+		return nil, err
+	}
+
+	updateSetting.Value = value
+	updateGlobalSetting, err := steveclient.SteveType(ManagementSetting).Update(globalSetting, updateSetting)
+	if err != nil {
+		return nil, err
+	}
+	return updateGlobalSetting, nil
+}


### PR DESCRIPTION
Extension in this PR are to enhance the extensions for rbac checks. Once approved, this needs a back port in 2.7 and 2.8 branches as well.

Rancher PR that uses the extensions from this PR: https://github.com/rancher/rancher/pull/43661