### PR TITLE
Refactor nodetemplates extension

### DIFF
--- a/extensions/rke1/nodetemplates/aws/create.go
+++ b/extensions/rke1/nodetemplates/aws/create.go
@@ -21,8 +21,16 @@ func CreateAWSNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.NodeTe
 		AmazonEC2NodeTemplateConfig: &amazonEC2NodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/rke1/nodetemplates/aws_config.go
+++ b/extensions/rke1/nodetemplates/aws_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the Amazon node template config
-const AmazonEC2NodeTemplateConfigurationFileKey = "awsNodeTemplate"
+const AmazonEC2NodeTemplateConfigurationFileKey = "amazonec2Config"
 
 // AmazonNodeTemplateConfig is configuration need to create a Amazon node template
 type AmazonEC2NodeTemplateConfig struct {

--- a/extensions/rke1/nodetemplates/azure/create.go
+++ b/extensions/rke1/nodetemplates/azure/create.go
@@ -21,8 +21,16 @@ func CreateAzureNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.Node
 		AzureNodeTemplateConfig: &azureNodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AzureNodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/rke1/nodetemplates/azure_config.go
+++ b/extensions/rke1/nodetemplates/azure_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the Azure node template config
-const AzureNodeTemplateConfigurationFileKey = "azureNodeTemplate"
+const AzureNodeTemplateConfigurationFileKey = "azureConfig"
 
 // AzureNodeTemplateConfig is configuration need to create a Azure node template
 type AzureNodeTemplateConfig struct {

--- a/extensions/rke1/nodetemplates/harvester/create.go
+++ b/extensions/rke1/nodetemplates/harvester/create.go
@@ -21,8 +21,16 @@ func CreateHarvesterNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.
 		HarvesterNodeTemplateConfig: &harvesterNodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.HarvesterNodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/rke1/nodetemplates/harvester_config.go
+++ b/extensions/rke1/nodetemplates/harvester_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the Harvester node template config
-const HarvesterNodeTemplateConfigurationFileKey = "harvesterNodeTemplate"
+const HarvesterNodeTemplateConfigurationFileKey = "harvesterConfig"
 
 // HarvesterNodeTemplateConfig is configuration need to create a Harvester node template
 type HarvesterNodeTemplateConfig struct {

--- a/extensions/rke1/nodetemplates/linode/create.go
+++ b/extensions/rke1/nodetemplates/linode/create.go
@@ -21,8 +21,16 @@ func CreateLinodeNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.Nod
 		LinodeNodeTemplateConfig: &linodeNodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.LinodeNodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/rke1/nodetemplates/linode_config.go
+++ b/extensions/rke1/nodetemplates/linode_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the Linode node template config
-const LinodeNodeTemplateConfigurationFileKey = "linodeNodeTemplate"
+const LinodeNodeTemplateConfigurationFileKey = "linodeConfig"
 
 // LinodeNodeTemplateConfig is configuration need to create a Linode node template
 type LinodeNodeTemplateConfig struct {

--- a/extensions/rke1/nodetemplates/nodetemplates.go
+++ b/extensions/rke1/nodetemplates/nodetemplates.go
@@ -1,8 +1,16 @@
 package nodetemplates
 
 import (
+	"maps"
+
+	"github.com/pkg/errors"
 	"github.com/rancher/norman/types"
+	"gopkg.in/yaml.v2"
+	"k8s.io/utils/strings/slices"
 )
+
+// The json/yaml config key for the node template config
+const NodeTemplateConfigurationFileKey = "nodeTemplate"
 
 // NodeTemplate is the main struct needed to create a node template for an RKE1 cluster
 type NodeTemplate struct {
@@ -38,4 +46,74 @@ type NodeTemplate struct {
 	Type                            string                           `json:"type,omitempty" yaml:"type,omitempty"`
 	UUID                            string                           `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	UseInternalIPAddress            *bool                            `json:"useInternalIpAddress,omitempty" yaml:"useInternalIpAddress,omitempty"`
+}
+
+func providerTemplateConfigKeys() []string {
+	return []string{
+		AmazonEC2NodeTemplateConfigurationFileKey,
+		AzureNodeTemplateConfigurationFileKey,
+		HarvesterNodeTemplateConfigurationFileKey,
+		LinodeNodeTemplateConfigurationFileKey,
+		VmwareVsphereNodeTemplateConfigurationFileKey,
+	}
+}
+
+// MergeOverride merges two NodeTemplate objects by overriding fields from n1 with fields from n2
+//   - preserves fields not present in n2
+//   - deletes all provider keys except the specified providerTemplateConfigKey from both NodeTemplate objects before merging
+//
+// providerTemplateConfigKey: The key representing the provider template configuration to preserve during merging
+//
+// returns a pointer to the merged NodeTemplate and an error if any
+func (n1 *NodeTemplate) MergeOverride(n2 *NodeTemplate, providerTemplateConfigKey string) (*NodeTemplate, error) {
+	var n1Data map[string]any
+	n1YAML, err := yaml.Marshal(&n1)
+	if err != nil {
+		return nil, errors.Wrap(err, "MergeOverride: ")
+	}
+	err = yaml.Unmarshal(n1YAML, &n1Data)
+	if err != nil {
+		return nil, errors.Wrap(err, "MergeOverride: ")
+	}
+
+	var n2Data map[string]any
+	n2YAML, err := yaml.Marshal(&n2)
+	if err != nil {
+		return nil, errors.Wrap(err, "MergeOverride: ")
+	}
+	err = yaml.Unmarshal(n2YAML, &n2Data)
+	if err != nil {
+		return nil, errors.Wrap(err, "MergeOverride: ")
+	}
+
+	configKeys := providerTemplateConfigKeys()
+	var keyPosition int
+	for pos, configKey := range configKeys {
+		if configKey == providerTemplateConfigKey {
+			keyPosition = pos
+		}
+	}
+
+	// Delete all other provider keys from both nodetemplates
+	keysToDelete := append(configKeys[:keyPosition], configKeys[keyPosition+1:]...)
+	maps.DeleteFunc(n1Data, func(k string, v any) bool {
+		return slices.Contains(keysToDelete, k) && k != providerTemplateConfigKey
+	})
+	maps.DeleteFunc(n2Data, func(k string, v any) bool {
+		return slices.Contains(keysToDelete, k) && k != providerTemplateConfigKey
+	})
+
+	maps.Copy(n1Data, n2Data)
+
+	tempData, err := yaml.Marshal(n1Data)
+	if err != nil {
+		return nil, errors.Wrap(err, "MergeOverride: ")
+	}
+
+	var mergedNodeTemplate = NodeTemplate{}
+	err = yaml.Unmarshal(tempData, &mergedNodeTemplate)
+	if err != nil {
+		return nil, errors.Wrap(err, "MergeOverride: ")
+	}
+	return &mergedNodeTemplate, nil
 }

--- a/extensions/rke1/nodetemplates/vsphere/create.go
+++ b/extensions/rke1/nodetemplates/vsphere/create.go
@@ -21,8 +21,16 @@ func CreateVSphereNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.No
 		VmwareVsphereNodeTemplateConfig: &vmwarevsphereNodeTemplateConfig,
 	}
 
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
+
+	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.VmwareVsphereNodeTemplateConfigurationFileKey)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &nodetemplates.NodeTemplate{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/rke1/nodetemplates/vsphere_config.go
+++ b/extensions/rke1/nodetemplates/vsphere_config.go
@@ -1,7 +1,7 @@
 package nodetemplates
 
 // The json/yaml config key for the VSphere node template config
-const VmwareVsphereNodeTemplateConfigurationFileKey = "vmwarevsphereNodeTemplate"
+const VmwareVsphereNodeTemplateConfigurationFileKey = "vmwarevsphereConfig"
 
 // VmwareVsphereNodeTemplateConfig is configuration need to create a VSphere node template
 type VmwareVsphereNodeTemplateConfig struct {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
It is currently not possible to set top-level NodeTemplate fields via configfile. The current implementation assumes defaults and is difficult to modify on the fly. Provider-specific node template configuration file keys do not match the top-level NodeTemplate struct keys.
 
## Solution
- Enable setting top-level nodetemplate fields
- Enable setting entire nodetemplate via config file
- **BREAKING** Update provider-specific configfile keys to match their top-level NodeTemplate key
- Add custom merge function for NodeTemplate
- Can still set provider-specific nodetemplate configuration separately via config file
- Should maintain backwards-compatibility if the top-level NodeTemplate configuration key is not present in the config file
- Specification of the updated provider-specific node template configuration keys should correctly overwrite the top-level NodeTemplate's provider config if specified

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Tested locally, have not tested via Jenkins

Example AWS config.yaml:
```
nodeTemplate:
  engineInstallURL: "testNT"
  name:             "testNTName"
  amazonec2Config:
    accessKey: ""
    secretKey: ""
    ami: ""
    blockDurationMinutes: "0"
    # deviceName: null
    encryptEbsVolume: false
    # endpoint: null
    # httpEndpoint: null
    # httpTokens: null
    iamInstanceProfile: ""
    insecureTransport: false
    instanceType: ""
    # keyPairName: null
    # kmsKey: null
    monitoring: false
    privateAddressOnly: false
    region: ""
    requestSpotInstance: true
    retries: "5"
    rootSize: 32
    securityGroup:
      - ""
    # securityGroupReadonly: null
    # sessionToken: null
    sshUser: "ubuntu"
    subnetId: null
    tags: "Owner,shepherd,"
    type: "amazonec2Config"
    # usePrivateAddress: false
    # useEbsOptimizedInstance: false
    volumeType: "gp2"
    vpcId: ""
    zone: ""
amazonec2Config:
  accessKey: ""
  secretKey: ""
  ami: ""
  blockDurationMinutes: "0"
  # deviceName: null
  encryptEbsVolume: false
  # endpoint: null
  # httpEndpoint: null
  # httpTokens: null
  iamInstanceProfile: ""
  insecureTransport: false
  instanceType: ""
  # keyPairName: null
  # kmsKey: null
  monitoring: false
  privateAddressOnly: false
  region: ""
  requestSpotInstance: true
  retries: "5"
  rootSize: 32
  securityGroup:
    - "open-all"
  # securityGroupReadonly: null
  # sessionToken: null
  sshUser: "ubuntu"
  subnetId: null
  tags: "Owner,shepherd,"
  type: "amazonec2Config"
  # usePrivateAddress: false
  # useEbsOptimizedInstance: false
  volumeType: "gp2"
  vpcId: ""
  zone: ""
```

Some basic scenarios that should be tested:

1. `nodeTemplate` config key is defined with a sub-config key defined (ex: `amazonec2Config`) beneath it

    ```
    nodeTemplate:
      name: "some name"
      engineInstallURL: "some url"
      amazonec2Config:
         # all required keys defined here
     ...
    ```

2. `nodeTemplate` config key is defined with a sub-config key defined at the top-level and beneath the nodeTemplate key
  - The top-level sub-config key should override any matching keys defined in the nodeTemplate sub-config key
     ex: `amazonec2Config` overrides `nodeTemplate.amazonec2Config`
    ```
    nodeTemplate:
      name: "some name"
      engineInstallURL: "some url"
      amazonec2Config:
         # desired keys defined here
    amazonec2Config:
         # all remaining required keys defined here
     ...
    ```
3. `nodeTemplate` config key is *not* defined and only the sub-config key is defined at the top-level

    ```
    amazonec2Config:
      # all required keys defined here
     ...
   ```

4. `nodetemplate` config key is defined with *no* sub-config key defined beneath it, and a sub-config key is defined at the top-level

    ```
    nodeTemplate:
      name: "some name"
      engineInstallURL: "some url"
    amazonec2Config:
         # all required keys defined here
     ...
    ```

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->