### PR TITLE
Updates to the following golang test framework extensions: defaults, kubeconfig, and provisioning

### DIFF
--- a/extensions/kubeconfig/exec.go
+++ b/extensions/kubeconfig/exec.go
@@ -2,6 +2,7 @@ package kubeconfig
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -73,7 +74,7 @@ func KubectlExec(restConfig *restclient.Config, podName, namespace string, comma
 	}
 
 	logStreamer := &LogStreamer{}
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
 		Stdin:  nil,
 		Stdout: logStreamer,
 		Stderr: os.Stderr,

--- a/extensions/kubeconfig/podlogs.go
+++ b/extensions/kubeconfig/podlogs.go
@@ -74,6 +74,8 @@ func GetPodLogs(client *rancher.Client, clusterID string, podName string, namesp
 	return logs, nil
 }
 
+// GetPodLogsWithOpts fetches logs from a Kubernetes pod, with an optional PodLogOptions object that can be used to finetune which Logs get pulled.
+// Buffer size (e.g., '64KB', '8MB', '1GB') influences log reading; an empty string causes no buffering.
 func GetPodLogsWithOpts(client *rancher.Client, clusterID string, podName string, namespace string, bufferSizeStr string, opts *corev1.PodLogOptions) (string, error) {
 	var restConfig *restclient.Config
 

--- a/extensions/kubeconfig/pods.go
+++ b/extensions/kubeconfig/pods.go
@@ -1,0 +1,57 @@
+package kubeconfig
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+	k8Scheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+func GetPods(client *rancher.Client, clusterID string, namespace string, listOptions *metav1.ListOptions) ([]corev1.Pod, error) {
+
+	kubeConfig, err := GetKubeconfig(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(k8Scheme.Scheme)
+	restConfig.ContentConfig.GroupVersion = &podGroupVersion
+	restConfig.APIPath = apiPath
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), *listOptions)
+	if err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
+}
+
+func GetPodNames(client *rancher.Client, clusterID string, namespace string, listOptions *metav1.ListOptions) ([]string, error) {
+	pods, err := GetPods(client, clusterID, namespace, listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	if len(names) == 0 {
+		return nil, errors.New("GetPodNames: no pod names found")
+	}
+
+	return names, nil
+}

--- a/extensions/kubeconfig/pods.go
+++ b/extensions/kubeconfig/pods.go
@@ -12,6 +12,7 @@ import (
 	k8Scheme "k8s.io/client-go/kubernetes/scheme"
 )
 
+// GetPods utilizes the upstream K8s corev1 client (from the rancher.Client) to get the given cluster's Pods based on any List options passed
 func GetPods(client *rancher.Client, clusterID string, namespace string, listOptions *metav1.ListOptions) ([]corev1.Pod, error) {
 
 	kubeConfig, err := GetKubeconfig(client, clusterID)
@@ -39,6 +40,7 @@ func GetPods(client *rancher.Client, clusterID string, namespace string, listOpt
 	return pods.Items, nil
 }
 
+// GetPodNames calls GetPods and filters the list of Pods and extracts their names into a []string
 func GetPodNames(client *rancher.Client, clusterID string, namespace string, listOptions *metav1.ListOptions) ([]string, error) {
 	pods, err := GetPods(client, clusterID, namespace, listOptions)
 	if err != nil {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
- There was no function to get pod logs with customized PodOptions
- There was no function to get a []string of pod names
- The "Verify Cluster" functions all default to a 30 minute timeout that is not configurable, this limits the usage of these functions if/when provisioning/creating many clusters at once
 
## Solution
- Update deprecated Stream() call to StreamWithContext()
- Add GetPodLogsWithOpts() to `extensions/kubeconfig`
- Add GetPods() and GetPodNames() `extensions/kubeconfig`
- Add "Verify Cluster" function variants that also take a custom timeout as input (defaults to 30-minute default of the non-custom function variants)
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
