### PR TITLE
[v2.8] Fix etcdctl version check for static and dynamic tests

### DIFF
--- a/extensions/rke1/componentchecks/etcdversion.go
+++ b/extensions/rke1/componentchecks/etcdversion.go
@@ -26,7 +26,7 @@ func CheckETCDVersion(client *rancher.Client, nodes []*nodes.Node, clusterID str
 		externalIP := rancherNode.Annotations["rke.cattle.io/external-ip"]
 		etcdRole := rancherNode.Labels["node-role.kubernetes.io/etcd"] == "true"
 
-		if etcdRole {
+		if etcdRole == true {
 			for _, node := range nodes {
 				if strings.Contains(node.PublicIPAddress, externalIP) {
 					command := "docker exec etcd etcdctl version"


### PR DESCRIPTION
### PR Description
When running the RKE1 custom cluster provisioning tests, there is a specific check for the `etcdctl` version. When running the DynamicInput tests, this passes. For the static TDD tests, they fail.

Troubleshooting, it is because the etcd node has the private IP address in the external AND internal IP address for only the static tests; the dynamic tests do not share this problem.

### Solution
To fix this/polish up the check further, removing the additional if condition for checking the externalIP; so long as the `etcdRole` is true, run the docker exec command. This will occur only on the first etcd node, then it will break the check.