### PR TITLE
[2.8] Move Upgrade Test Configurations and Load Functions

### DIFF
--- a/extensions/pipeline/releaseupgrade.go
+++ b/extensions/pipeline/releaseupgrade.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"os"
 
+	"github.com/rancher/shepherd/extensions/upgradeinput"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -45,12 +46,6 @@ type TestCases struct {
 	RunFlag string `yaml:"runFlag" json:"runFlag"`
 }
 
-// Features is a struct that dictates what features to run a cluster pre/post upgrade
-type Features struct {
-	Chart   *bool `json:"chart" yaml:"chart" default:"false"`
-	Ingress *bool `json:"ingress" yaml:"ingress" default:"false"`
-}
-
 // HAConfigKey is the key name of HAConfig values in the cattle config
 const HAConfigKey = "ha"
 
@@ -87,24 +82,24 @@ type RancherClusters struct {
 
 // RancherCluster is a struct that contains related information about the downstream cluster that's going to be created and upgraded.
 type RancherCluster struct {
-	Provider                   string   `yaml:"provider" json:"provider"`
-	KubernetesVersion          string   `yaml:"kubernetesVersion" json:"kubernetesVersion"`
-	KubernetesVersionToUpgrade string   `yaml:"kubernetesVersionToUpgrade" json:"kubernetesVersionToUpgrade"`
-	Image                      string   `yaml:"image" json:"image"`
-	CNIs                       []string `yaml:"cni" json:"cni"`
-	FeaturesToTest             Features `yaml:"enabledFeatures" json:"enabledFeatures" default:""`
-	Tags                       string   `yaml:"tags" json:"tags" default:""`
-	RunFlag                    string   `yaml:"runFlag" json:"runFlag" default:""`
-	SSHUser                    string   `yaml:"sshUser" json:"sshUser" default:""`
-	VolumeType                 string   `yaml:"volumeType" json:"volumeType" default:""`
+	Provider                   string                `yaml:"provider" json:"provider"`
+	KubernetesVersion          string                `yaml:"kubernetesVersion" json:"kubernetesVersion"`
+	KubernetesVersionToUpgrade string                `yaml:"kubernetesVersionToUpgrade" json:"kubernetesVersionToUpgrade"`
+	Image                      string                `yaml:"image" json:"image"`
+	CNIs                       []string              `yaml:"cni" json:"cni"`
+	FeaturesToTest             upgradeinput.Features `yaml:"enabledFeatures" json:"enabledFeatures" default:""`
+	Tags                       string                `yaml:"tags" json:"tags" default:""`
+	RunFlag                    string                `yaml:"runFlag" json:"runFlag" default:""`
+	SSHUser                    string                `yaml:"sshUser" json:"sshUser" default:""`
+	VolumeType                 string                `yaml:"volumeType" json:"volumeType" default:""`
 }
 
 // HostedCluster is a struct that contains related information about the downstream cluster that's going to be created and upgraded.
 type HostedCluster struct {
-	Provider                   string   `yaml:"provider" json:"provider"`
-	KubernetesVersion          string   `yaml:"kubernetesVersion" json:"kubernetesVersion"`
-	KubernetesVersionToUpgrade string   `yaml:"kubernetesVersionToUpgrade" json:"kubernetesVersionToUpgrade"`
-	FeaturesToTest             Features `yaml:"enabledFeatures" json:"enabledFeatures" default:""`
+	Provider                   string                `yaml:"provider" json:"provider"`
+	KubernetesVersion          string                `yaml:"kubernetesVersion" json:"kubernetesVersion"`
+	KubernetesVersionToUpgrade string                `yaml:"kubernetesVersionToUpgrade" json:"kubernetesVersionToUpgrade"`
+	FeaturesToTest             upgradeinput.Features `yaml:"enabledFeatures" json:"enabledFeatures" default:""`
 }
 
 // GenerateDefaultReleaseUpgradeConfig is a function that creates the ReleaseUpgradeConfig with its default values.

--- a/extensions/upgradeinput/config.go
+++ b/extensions/upgradeinput/config.go
@@ -1,0 +1,30 @@
+package upgradeinput
+
+type PSACT string
+
+const (
+	ConfigurationFileKey = "upgradeInput" // ConfigurationFileKey is used to parse the configuration of upgrade tests.
+	localClusterID       = "local"        // localClusterID is a string to used ignore this cluster in comparisons
+	LatestKey            = "latest"       // latestKey is a string to determine automatically version pooling to the latest possible
+)
+
+// Config is a struct that stores multiple clusters and their testing options to load from the configuration file
+type Config struct {
+	Clusters []Cluster `json:"clusters" yaml:"clusters" default:"[]"`
+}
+
+// Cluster is a struct that's used to configure a single cluster to be used in an upgrade test
+type Cluster struct {
+	Name              string   `json:"name" yaml:"name" default:""`
+	VersionToUpgrade  string   `json:"versionToUpgrade" yaml:"versionToUpgrade" default:""`
+	PSACT             string   `json:"psact" yaml:"psact" default:""`
+	FeaturesToTest    Features `json:"enabledFeatures" yaml:"enabledFeatures" default:""`
+	IsLatestVersion   bool
+	IsUpgradeDisabled bool
+}
+
+// Features is a struct that stores test case options for a single cluster
+type Features struct {
+	Chart   *bool `json:"chart" yaml:"chart" default:"false"`
+	Ingress *bool `json:"ingress" yaml:"ingress" default:"false"`
+}

--- a/extensions/upgradeinput/load.go
+++ b/extensions/upgradeinput/load.go
@@ -1,0 +1,136 @@
+package upgradeinput
+
+import (
+	"github.com/pkg/errors"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/environmentflag"
+)
+
+// loadUpgradeKubernetesConfig is a test helper function to get required slice of Clusters struct. Returns error if any.
+// Contains two different config options to the upgrade kubernetes test:
+//  1. A flag called “all” is only requirement, upgrades all clusters except local to the latest available
+//  2. An additional config field called update with slice of Clusters struct,
+//     for choosing some clusters to upgrade (version is optional, by default, empty string skips the test
+//     and "latest" upgrades to the latest available.)
+func LoadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Cluster, err error) {
+	upgradeConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, upgradeConfig)
+
+	isConfigEmpty := len(upgradeConfig.Clusters) == 0
+	isFlagDeclared := client.Flags.GetValue(environmentflag.KubernetesUpgradeAllClusters)
+
+	if isConfigEmpty && !isFlagDeclared {
+		return clusters, errors.Wrap(err, "config doesn't match the requirements")
+	}
+
+	isUpgradeAllClusters := isFlagDeclared && isConfigEmpty
+	isUpgradeSomeClusters := !isConfigEmpty && !isUpgradeAllClusters
+
+	if isUpgradeAllClusters {
+		clusterList, err := listDownstreamClusters(client)
+		if err != nil {
+			return clusters, errors.Wrap(err, "couldn't list clusters")
+		}
+
+		for i := range clusterList {
+			cluster := new(Cluster)
+
+			cluster.Name = clusterList[i]
+			cluster.IsLatestVersion = true
+
+			clusters = append(clusters, *cluster)
+		}
+	} else if isUpgradeSomeClusters {
+		for _, c := range upgradeConfig.Clusters {
+			cluster := new(Cluster)
+
+			cluster.Name = c.Name
+			cluster.VersionToUpgrade = c.VersionToUpgrade
+			cluster.PSACT = c.PSACT
+
+			isVersionFieldLatest := cluster.VersionToUpgrade == LatestKey
+			if isVersionFieldLatest {
+				cluster.IsLatestVersion = true
+			}
+
+			isUpgradeDisabled := cluster.VersionToUpgrade == ""
+			if isUpgradeDisabled {
+				cluster.IsUpgradeDisabled = true
+			}
+
+			clusters = append(clusters, *cluster)
+		}
+	}
+
+	return
+}
+
+// loadUpgradeKubernetesConfig is a test helper function to get required slice of Clusters struct. Returns error if any.
+// Contains two different config options to workload upgrade test:
+//  1. A flag called “all” is only requirement, tests all clusters with ingrss and charts options disabled
+//  2. Some option that's up to user input
+func LoadUpgradeWorkloadConfig(client *rancher.Client) (clusters []Cluster, err error) {
+	upgradeConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, upgradeConfig)
+
+	isConfigEmpty := len(upgradeConfig.Clusters) == 0
+	isFlagDeclared := client.Flags.GetValue(environmentflag.WorkloadUpgradeAllClusters)
+
+	if isConfigEmpty && !isFlagDeclared {
+		return clusters, errors.Wrap(err, "config doesn't match the requirements")
+	}
+
+	isUpgradeAllClusters := isFlagDeclared && isConfigEmpty
+	isUpgradeSomeClusters := !isConfigEmpty && !isUpgradeAllClusters
+
+	if isUpgradeAllClusters {
+		clusterList, err := listDownstreamClusters(client)
+		if err != nil {
+			return clusters, errors.Wrap(err, "couldn't list clusters")
+		}
+
+		for i := range clusterList {
+			cluster := new(Cluster)
+
+			cluster.Name = clusterList[i]
+			ingress := false
+			chart := false
+			cluster.FeaturesToTest = Features{
+				Ingress: &ingress,
+				Chart:   &chart,
+			}
+
+			clusters = append(clusters, *cluster)
+		}
+	} else if isUpgradeSomeClusters {
+		for _, c := range upgradeConfig.Clusters {
+			cluster := new(Cluster)
+
+			cluster.Name = c.Name
+			cluster.FeaturesToTest = c.FeaturesToTest
+			cluster.PSACT = c.PSACT
+
+			clusters = append(clusters, *cluster)
+		}
+	}
+
+	return
+}
+
+func listDownstreamClusters(client *rancher.Client) (clusterNames []string, err error) {
+	clusterList, err := client.Management.Cluster.List(&types.ListOpts{})
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't list downstream clusters")
+	}
+
+	for i, c := range clusterList.Data {
+		isLocalCluster := c.ID == localClusterID
+		if !isLocalCluster {
+			clusterNames = append(clusterNames, clusterList.Data[i].Name)
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
Adds `upgradeinput` package with upgrade tests configuration and its load functions.