### PR TITLE
[v2.8] Add support for rotating worker nodes after creating an etcd snapshot

### DIFF
--- a/extensions/etcdsnapshot/config.go
+++ b/extensions/etcdsnapshot/config.go
@@ -12,4 +12,5 @@ type Config struct {
 	WorkerConcurrencyValue       string `json:"workerConcurrencyValue" yaml:"workerConcurrencyValue"`
 	WorkerUnavailableValue       string `json:"workerUnavailableValue" yaml:"workerUnavailableValue"`
 	RecurringRestores            int    `json:"recurringRestores" yaml:"recurringRestores"`
+	ReplaceWorkerNode            bool   `json:"replaceWorkerNode" yaml:"replaceWorkerNode"`
 }

--- a/extensions/etcdsnapshot/etcdsnapshot.go
+++ b/extensions/etcdsnapshot/etcdsnapshot.go
@@ -1,6 +1,7 @@
 package etcdsnapshot
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -203,19 +204,45 @@ func CreateRKE2K3SSnapshot(client *rancher.Client, clusterName string) error {
 }
 
 // RestoreRKE1Snapshot is a helper function to restore a snapshot on an RKE1 cluster. Returns error if any.
-func RestoreRKE1Snapshot(client *rancher.Client, clusterName string, snapshotRestore *management.RestoreFromEtcdBackupInput) error {
+func RestoreRKE1Snapshot(client *rancher.Client, clusterName string, snapshotRestore *management.RestoreFromEtcdBackupInput, initialControlPlaneValue, initialWorkerValue string) error {
 	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
 	if err != nil {
 		return err
 	}
 
-	clusterResp, err := client.Management.Cluster.ByID(clusterID)
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	if err != nil {
+		return err
+	}
+
+	updatedCluster := cluster
+
+	updatedCluster.RancherKubernetesEngineConfig.UpgradeStrategy.MaxUnavailableControlplane = initialControlPlaneValue
+	updatedCluster.RancherKubernetesEngineConfig.UpgradeStrategy.MaxUnavailableWorker = initialWorkerValue
+
+	_, err = client.Management.Cluster.Update(cluster, updatedCluster)
 	if err != nil {
 		return err
 	}
 
 	logrus.Infof("Restoring snapshot: %v", snapshotRestore.EtcdBackupID)
-	err = client.Management.Cluster.ActionRestoreFromEtcdBackup(clusterResp, snapshotRestore)
+	err = client.Management.Cluster.ActionRestoreFromEtcdBackup(cluster, snapshotRestore)
+	if err != nil {
+		return err
+	}
+
+	err = wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, defaults.ThirtyMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
+		clusterResp, err := client.Management.Cluster.ByID(clusterID)
+		if err != nil {
+			return false, nil
+		}
+
+		if clusterResp.State == active {
+			return true, nil
+		}
+
+		return false, nil
+	})
 	if err != nil {
 		return err
 	}
@@ -223,14 +250,16 @@ func RestoreRKE1Snapshot(client *rancher.Client, clusterName string, snapshotRes
 	return nil
 }
 
-// CreateRKE2K3SSnapshot is a helper function to restore a snapshot on an RKE2 or k3s cluster. Returns error if any.
-func RestoreRKE2K3SSnapshot(client *rancher.Client, clusterName string, snapshotRestore *rkev1.ETCDSnapshotRestore) error {
+// RestoreRKE2K3SSnapshot is a helper function to restore a snapshot on an RKE2 or k3s cluster. Returns error if any.
+func RestoreRKE2K3SSnapshot(client *rancher.Client, clusterName string, snapshotRestore *rkev1.ETCDSnapshotRestore, initialControlPlaneValue, initialWorkerValue string) error {
 	clusterObject, existingSteveAPIObject, err := clusters.GetProvisioningClusterByName(client, clusterName, fleetNamespace)
 	if err != nil {
 		return err
 	}
 
 	clusterObject.Spec.RKEConfig.ETCDSnapshotRestore = snapshotRestore
+	clusterObject.Spec.RKEConfig.UpgradeStrategy.ControlPlaneConcurrency = initialControlPlaneValue
+	clusterObject.Spec.RKEConfig.UpgradeStrategy.WorkerConcurrency = initialWorkerValue
 
 	logrus.Infof("Restoring snapshot: %v", snapshotRestore.Name)
 	_, err = client.Steve.SteveType(ProvisioningSteveResouceType).Update(existingSteveAPIObject, clusterObject)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Automate rotating nodes after creating an etcd snapshot](https://github.com/rancher/qa-tasks/issues/989)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

v2.8 backport of https://github.com/rancher/shepherd/pull/59