### PR TITLE
[v2.7] Add support for rotating worker nodes after creating an etcd snapshot

### DIFF
--- a/extensions/etcdsnapshot/config.go
+++ b/extensions/etcdsnapshot/config.go
@@ -12,4 +12,5 @@ type Config struct {
 	WorkerConcurrencyValue       string `json:"workerConcurrencyValue" yaml:"workerConcurrencyValue"`
 	WorkerUnavailableValue       string `json:"workerUnavailableValue" yaml:"workerUnavailableValue"`
 	RecurringRestores            int    `json:"recurringRestores" yaml:"recurringRestores"`
+	ReplaceWorkerNode            bool   `json:"replaceWorkerNode" yaml:"replaceWorkerNode"`
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> [Automate rotating nodes after creating an etcd snapshot](https://github.com/rancher/qa-tasks/issues/989)
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

v2.7 backport of https://github.com/rancher/shepherd/pull/59