### PR TITLE
[2.8] Update Rancher Client Configurations and RKE Client to Have Different SSH Configuration Options

### DIFF
--- a/clients/rancher/config.go
+++ b/clients/rancher/config.go
@@ -5,13 +5,13 @@ const ConfigurationFileKey = "rancher"
 
 // Config is configuration need to test against a rancher instance
 type Config struct {
-	Host          string `yaml:"host"`
-	AdminToken    string `yaml:"adminToken"`
-	AdminPassword string `yaml:"adminPassword"`
-	Insecure      *bool  `yaml:"insecure" default:"true"`
-	Cleanup       *bool  `yaml:"cleanup" default:"true"`
-	CAFile        string `yaml:"caFile" default:""`
-	CACerts       string `yaml:"caCerts" default:""`
-	ClusterName   string `yaml:"clusterName" default:""`
-	ShellImage    string `yaml:"shellImage" default:""`
+	Host          string `yaml:"host" json:"host"`
+	AdminToken    string `yaml:"adminToken" json:"adminToken"`
+	AdminPassword string `yaml:"adminPassword" json:"adminPassword"`
+	Insecure      *bool  `yaml:"insecure" json:"insecure" default:"true"`
+	Cleanup       *bool  `yaml:"cleanup" json:"cleanup" default:"true"`
+	CAFile        string `yaml:"caFile" json:"caFile" default:""`
+	CACerts       string `yaml:"caCerts" json:"caCerts" default:""`
+	ClusterName   string `yaml:"clusterName" json:"clusterName" default:""`
+	ShellImage    string `yaml:"shellImage" json:"shellImage" default:""`
 }

--- a/clients/rkecli/config.go
+++ b/clients/rkecli/config.go
@@ -1,0 +1,9 @@
+package rkecli
+
+const ConfigurationFileKey = "rke"
+
+// RKE configuration required to run rkecli and up
+type Config struct {
+	SSHKey  string `json:"sshKey,omitempty" yaml:"sshKey,omitempty" default:""`
+	SSHPath string `json:"sshPath,omitempty" yaml:"sshPath,omitempty" default:""`
+}

--- a/clients/rkecli/state.go
+++ b/clients/rkecli/state.go
@@ -13,8 +13,8 @@ import (
 	v3 "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/configmaps"
+	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/file"
-	"github.com/rancher/shepherd/pkg/nodes"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -26,6 +26,9 @@ const dirName = "rke-cattle-test-dir"
 // In that dir, it generates state and cluster files from the state configmap.
 // Returns generated state and cluster files' paths.
 func NewRKEConfigs(client *rancher.Client) (stateFilePath, clusterFilePath string, err error) {
+	rkeConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, rkeConfig)
+
 	err = file.NewDir(dirName)
 	if err != nil {
 		return
@@ -36,7 +39,7 @@ func NewRKEConfigs(client *rancher.Client) (stateFilePath, clusterFilePath strin
 		return
 	}
 
-	clusterFilePath, err = NewClusterFile(state, dirName)
+	clusterFilePath, err = NewClusterFile(state, dirName, rkeConfig)
 	if err != nil {
 		return
 	}
@@ -106,7 +109,7 @@ func UpdateKubernetesVersion(kubernetesVersion, clusterFilePath string) error {
 
 // NewClusterFile is a function that generates new cluster.yml file from the full state.
 // Returns the generated file's path.
-func NewClusterFile(state *cluster.FullState, dirName string) (clusterFilePath string, err error) {
+func NewClusterFile(state *cluster.FullState, dirName string, config *Config) (clusterFilePath string, err error) {
 	extension := "yml"
 	rkeConfigFileName := fmt.Sprintf("%v/%v.%v", dirName, filePrefix, extension)
 
@@ -116,9 +119,17 @@ func NewClusterFile(state *cluster.FullState, dirName string) (clusterFilePath s
 	rkeConfig.Version = currentRkeConfig.Version
 	rkeConfig.Nodes = currentRkeConfig.Nodes
 
-	rkeConfig.SSHKeyPath = appendSSHPath(currentRkeConfig.SSHKeyPath)
-	for i := range rkeConfig.Nodes {
-		rkeConfig.Nodes[i].SSHKeyPath = appendSSHPath(rkeConfig.Nodes[i].SSHKeyPath)
+	if config.SSHKey != "" {
+		for i := range rkeConfig.Nodes {
+			rkeConfig.Nodes[i].SSHKey = config.SSHKey
+		}
+	} else if config.SSHPath != "" {
+		rkeConfig.SSHKeyPath = appendSSHPath(currentRkeConfig.SSHKeyPath, config.SSHPath)
+		for i := range rkeConfig.Nodes {
+			rkeConfig.Nodes[i].SSHKeyPath = appendSSHPath(rkeConfig.Nodes[i].SSHKeyPath, config.SSHPath)
+		}
+	} else {
+		return "", errors.Wrap(err, "rke SSHPath or SSHKey not configured")
 	}
 
 	marshaled, err := yaml.Marshal(rkeConfig)
@@ -191,15 +202,13 @@ func GetFullState(client *rancher.Client) (state *cluster.FullState, err error) 
 
 // appendSSHPath reads sshPath input from the cattle config file.
 // If the config input has a different prefix, adds the prefix.
-func appendSSHPath(sshPath string) string {
-	sshPathPrefix := nodes.GetSSHPath().SSHPath
-
-	if strings.HasPrefix(sshPath, sshPathPrefix) {
-		return sshPath
+func appendSSHPath(currentPath, newPath string) string {
+	if strings.HasPrefix(currentPath, newPath) {
+		return currentPath
 	}
 
 	ssh := ".ssh/"
-	sshPath = strings.TrimPrefix(sshPath, ssh)
+	currentPath = strings.TrimPrefix(currentPath, ssh)
 
-	return fmt.Sprintf(sshPathPrefix + "/" + sshPath)
+	return fmt.Sprintf(newPath + "/" + currentPath)
 }

--- a/extensions/pipeline/releaseupgrade.go
+++ b/extensions/pipeline/releaseupgrade.go
@@ -68,16 +68,17 @@ const ClustersConfigKey = "clusters"
 
 // Clusters is a struct that contains cluster types.
 type Clusters struct {
-	RKE1Clusters   RancherClusters `yaml:"rke1" json:"rke1"`
-	RKE2Clusters   RancherClusters `yaml:"rke2" json:"rke2"`
-	K3sClusters    RancherClusters `yaml:"k3s" json:"k3s"`
-	HostedClusters []HostedCluster `yaml:"hosted" json:"hosted"`
+	Local  *RancherCluster `yaml:"local" json:"local"`
+	RKE1   RancherClusters `yaml:"rke1" json:"rke1"`
+	RKE2   RancherClusters `yaml:"rke2" json:"rke2"`
+	K3s    RancherClusters `yaml:"k3s" json:"k3s"`
+	Hosted []HostedCluster `yaml:"hosted" json:"hosted"`
 }
 
 // RancherClusters is a struct that contains slice of custom and node providers as ProviderCluster type.
 type RancherClusters struct {
-	CustomClusters       []RancherCluster `yaml:"custom" json:"custom"`
-	NodeProviderClusters []RancherCluster `yaml:"nodeProvider" json:"nodeProvider"`
+	Custom       []RancherCluster `yaml:"custom" json:"custom"`
+	NodeProvider []RancherCluster `yaml:"nodeProvider" json:"nodeProvider"`
 }
 
 // RancherCluster is a struct that contains related information about the downstream cluster that's going to be created and upgraded.


### PR DESCRIPTION
- Updates Rancher client configuration to have JSON tags. 
- Add two different SSH options to RKECLI client and its configuration:
    1. SSHKey: mainly for corral and CI usage
    2. SSHPath: mainly for legacy tests and local usage
 - Update release upgrade-related glue codes with local options and simplify the field names.