### PR TITLE
make out-of-tree helpers public for additional testing during upgrades

### DIFF
--- a/extensions/charts/awsoutoftree.go
+++ b/extensions/charts/awsoutoftree.go
@@ -23,7 +23,7 @@ const (
 )
 
 // InstallAWSOutOfTreeChart installs the CSI chart for aws cloud provider in a given cluster.
-func InstallAWSOutOfTreeChart(client *rancher.Client, installOptions *InstallOptions, repoName, clusterID string) error {
+func InstallAWSOutOfTreeChart(client *rancher.Client, installOptions *InstallOptions, repoName, clusterID string, isLeaderMigration bool) error {
 	serverSetting, err := client.Management.Setting.ByID(serverURLSettingID)
 	if err != nil {
 		return err
@@ -42,7 +42,7 @@ func InstallAWSOutOfTreeChart(client *rancher.Client, installOptions *InstallOpt
 		DefaultRegistry: registrySetting.Value,
 	}
 
-	chartInstallAction := awsChartInstallAction(awsChartInstallActionPayload, repoName, kubeSystemNamespace, installOptions.ProjectID)
+	chartInstallAction := awsChartInstallAction(awsChartInstallActionPayload, repoName, kubeSystemNamespace, installOptions.ProjectID, isLeaderMigration)
 
 	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
 	if err != nil {
@@ -73,7 +73,7 @@ func InstallAWSOutOfTreeChart(client *rancher.Client, installOptions *InstallOpt
 }
 
 // awsChartInstallAction is a helper function that returns a chartInstallAction for aws out-of-tree chart.
-func awsChartInstallAction(awsChartInstallActionPayload *payloadOpts, repoName, chartNamespace, chartProject string) *types.ChartInstallAction {
+func awsChartInstallAction(awsChartInstallActionPayload *payloadOpts, repoName, chartNamespace, chartProject string, isLeaderMigration bool) *types.ChartInstallAction {
 	chartValues := map[string]interface{}{
 		"args": []interface{}{
 			"--use-service-account-credentials=true",
@@ -216,6 +216,9 @@ func awsChartInstallAction(awsChartInstallActionPayload *payloadOpts, repoName, 
 				"key":    "node-role.kubernetes.io/master",
 			},
 		},
+	}
+	if isLeaderMigration {
+		chartValues["args"] = append(chartValues["args"].([]interface{}), "--enable-leader-migration=true")
 	}
 
 	chartInstall := newChartInstall(

--- a/extensions/charts/verify.go
+++ b/extensions/charts/verify.go
@@ -2,6 +2,7 @@ package charts
 
 import (
 	"context"
+	"errors"
 
 	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher/catalog"
@@ -27,6 +28,10 @@ func VerifyChartInstall(client *catalog.Client, chartNamespace, chartName string
 		state := app.Status.Summary.State
 		if state == string(v1.StatusDeployed) {
 			return true, nil
+		}
+
+		if state == string(v1.StatusFailed) {
+			return false, errors.New("chart install has failed")
 		}
 		return false, nil
 	})

--- a/extensions/kubectl/template.go
+++ b/extensions/kubectl/template.go
@@ -31,7 +31,7 @@ const (
 	JobName               = "kubectl"
 )
 
-var importTimeout = int64(60 * 1)
+var importTimeout = int64(60 * 2)
 
 // CreateJobAndRunKubectlCommands is a helper to create a job and run the kubectl commands in the pods of the Job.
 // It then returns errors or nil from the job.


### PR DESCRIPTION
note; sometimes, the kubectl command is still flaky. This was pulled from this [PR](https://github.com/rancher/shepherd/pull/17) since it hasn't merged yet, which is an improvement from what's currently in but not 100% 

example of the bug from kubectl, hit intermittently
```
an error on the server ("unable to create impersonator account: error setting up impersonation for user user-kcbbw: impersonation: error ensuring secret for service account cattle-impersonation-user-kcbbw: error ensuring secret for service account [cattle-impersonation-system:cattle-impersonation-user-kcbbw]: timed out waiting for the condition") has prevented the request from succeeding
```

the other problem I'll see is this, followed by a timeout
```
child pods are preserved by default when jobs are deleted; set propagationPolicy=Background to remove them or set propagationPolicy=Orphan to suppress this warning
```
