### PR TITLE
[2.8] Adding extension for the global roles v2 webhook checks

### DIFF
--- a/extensions/kubeapi/rbac/delete.go
+++ b/extensions/kubeapi/rbac/delete.go
@@ -38,3 +38,19 @@ func DeleteGlobalRole(client *rancher.Client, globalRoleName string) error {
 	}
 	return nil
 }
+
+// DeleteRoletemplate is a helper function that uses the dynamic client to delete a Custom Cluster Role/ Project Role template by name
+func DeleteRoletemplate(client *rancher.Client, roleName string) error {
+	dynamicClient, err := client.GetDownStreamClusterClient(LocalCluster)
+	if err != nil {
+		return err
+	}
+
+	roleResource := dynamicClient.Resource(RoleTemplateGroupVersionResource)
+
+	err = roleResource.Delete(context.TODO(), roleName, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/extensions/kubeapi/rbac/update.go
+++ b/extensions/kubeapi/rbac/update.go
@@ -42,3 +42,71 @@ func UpdateGlobalRole(client *rancher.Client, updatedGlobalRole *v3.GlobalRole) 
 	}
 	return newGlobalRole, nil
 }
+
+// UpdateRoleTemplate is a helper function that uses the dynamic client to update an existing cluster role template
+func UpdateRoleTemplate(client *rancher.Client, updatedRoleTemplate *v3.RoleTemplate) (*v3.RoleTemplate, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(LocalCluster)
+	if err != nil {
+		return nil, err
+	}
+	roleTemplateUnstructured := dynamicClient.Resource(RoleTemplateGroupVersionResource)
+	roleTemplate, err := roleTemplateUnstructured.Get(context.TODO(), updatedRoleTemplate.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	currentRoleTemplate := &v3.RoleTemplate{}
+	err = scheme.Scheme.Convert(roleTemplate, currentRoleTemplate, roleTemplate.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	updatedRoleTemplate.ObjectMeta.ResourceVersion = currentRoleTemplate.ObjectMeta.ResourceVersion
+
+	unstructuredResp, err := roleTemplateUnstructured.Update(context.TODO(), unstructured.MustToUnstructured(updatedRoleTemplate), metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newRoleTemplate := &v3.RoleTemplate{}
+	err = scheme.Scheme.Convert(unstructuredResp, newRoleTemplate, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+	return newRoleTemplate, nil
+
+}
+
+// UpdateClusterRoleTemplateBindings is a helper function that uses the dynamic client to update an existing cluster role template binding
+func UpdateClusterRoleTemplateBindings(client *rancher.Client, existingCRTB *v3.ClusterRoleTemplateBinding, updatedCRTB *v3.ClusterRoleTemplateBinding) (*v3.ClusterRoleTemplateBinding, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(LocalCluster)
+	if err != nil {
+		return nil, err
+	}
+	crtbUnstructured := dynamicClient.Resource(ClusterRoleTemplateBindingGroupVersionResource).Namespace(existingCRTB.Namespace)
+	clusterRoleTemplateBinding, err := crtbUnstructured.Get(context.TODO(), existingCRTB.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	currentCRTB := &v3.ClusterRoleTemplateBinding{}
+	err = scheme.Scheme.Convert(clusterRoleTemplateBinding, currentCRTB, clusterRoleTemplateBinding.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	updatedCRTB.ObjectMeta.ResourceVersion = currentCRTB.ObjectMeta.ResourceVersion
+
+	unstructuredResp, err := crtbUnstructured.Update(context.TODO(), unstructured.MustToUnstructured(updatedCRTB), metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newCRTB := &v3.ClusterRoleTemplateBinding{}
+	err = scheme.Scheme.Convert(unstructuredResp, newCRTB, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+	return newCRTB, nil
+
+}


### PR DESCRIPTION
Depends on https://github.com/rancher/rancher/pull/43363

For the global roles v2 webhook checks, we need a few extensions:
1. Create Role templates
2. CreateClusterRoleTemplateBinding
3. DeleteClusterRoletemplate
4. UpdateRoleTemplate
5. UpdateClusterRoleTemplateBindings

All of these extensions are using dynamic clients[kubernetes API], so we only need to back port the fix in 2.8. Public API was introduces in 2.8, so these extensions need not be in 2.7. 