### PR TITLE
Helm and kubectl updates

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,7 +17,7 @@ linters-settings:
       disabled: true
     - name: exported
       disabled: false
-  goconst: 
+  goconst:
     min-len: 2
     min-occurrences: 10
     match-constant: true
@@ -39,3 +39,7 @@ issues:
     - ^*\.yaml$
     - ^*\.yml$
   exclude-generated-strict: true
+  exclude-rules:
+    - path: extensions/kubeconfig/podlogs.go
+      linters:
+        - forbidigo

--- a/clients/dynamic/dynamic.go
+++ b/clients/dynamic/dynamic.go
@@ -23,7 +23,7 @@ type Client struct {
 }
 
 // NewForConfig creates a new dynamic client or returns an error.
-func NewForConfig(ts *session.Session, inConfig *rest.Config) (dynamic.Interface, error) {
+func NewForConfig(ts *session.Session, inConfig *rest.Config) (*Client, error) {
 	logrus.Debugf("Dynamic Client Host:%s", inConfig.Host)
 
 	dynamicClient, err := dynamic.NewForConfig(inConfig)
@@ -44,7 +44,7 @@ func NewForConfig(ts *session.Session, inConfig *rest.Config) (dynamic.Interface
 //		  Version:  "v3",
 //		  Resource: "users",
 //	 }
-func (d *Client) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+func (d *Client) Resource(resource schema.GroupVersionResource) *NamespaceableResourceClient {
 	return &NamespaceableResourceClient{
 		NamespaceableResourceInterface: d.Interface.Resource(resource),
 		ts:                             d.ts,
@@ -59,7 +59,7 @@ type NamespaceableResourceClient struct {
 }
 
 // Namespace returns a dynamic.ResourceInterface that is embedded in ResourceClient, so ultimately its Create is overwritten.
-func (d *NamespaceableResourceClient) Namespace(s string) dynamic.ResourceInterface {
+func (d *NamespaceableResourceClient) Namespace(s string) *ResourceClient {
 	return &ResourceClient{
 		ResourceInterface: d.NamespaceableResourceInterface.Namespace(s),
 		ts:                d.ts,

--- a/clients/rancher/client.go
+++ b/clients/rancher/client.go
@@ -16,6 +16,7 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 
+	rancherDynamic "github.com/rancher/shepherd/clients/dynamic"
 	kubeProvisioning "github.com/rancher/shepherd/clients/provisioning"
 	"github.com/rancher/shepherd/clients/ranchercli"
 	kubeRKE "github.com/rancher/shepherd/clients/rke"
@@ -27,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -222,7 +222,7 @@ func (c *Client) GetClusterCatalogClient(clusterID string) (*catalog.Client, err
 }
 
 // GetRancherDynamicClient is a helper function that instantiates a dynamic client to communicate with the rancher host.
-func (c *Client) GetRancherDynamicClient() (dynamic.Interface, error) {
+func (c *Client) GetRancherDynamicClient() (*rancherDynamic.Client, error) {
 	dynamic, err := frameworkDynamic.NewForConfig(c.Session, c.restConfig)
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (c *Client) GetKubeAPIRKEClient() (*kubeRKE.Client, error) {
 }
 
 // GetDownStreamClusterClient is a helper function that instantiates a dynamic client to communicate with a specific cluster.
-func (c *Client) GetDownStreamClusterClient(clusterID string) (dynamic.Interface, error) {
+func (c *Client) GetDownStreamClusterClient(clusterID string) (*rancherDynamic.Client, error) {
 	restConfig := *c.restConfig
 	restConfig.Host = fmt.Sprintf("https://%s/k8s/clusters/%s", c.restConfig.Host, clusterID)
 
@@ -263,7 +263,7 @@ func (c *Client) GetDownStreamClusterClient(clusterID string) (dynamic.Interface
 }
 
 // SwitchContext is a helper function that changes the current context to `context` and instantiates a dynamic client
-func (c *Client) SwitchContext(context string, clientConfig *clientcmd.ClientConfig) (dynamic.Interface, error) {
+func (c *Client) SwitchContext(context string, clientConfig *clientcmd.ClientConfig) (*rancherDynamic.Client, error) {
 	overrides := clientcmd.ConfigOverrides{CurrentContext: context}
 
 	rawConfig, err := (*clientConfig).RawConfig()

--- a/extensions/codecoverage/codecoverage.go
+++ b/extensions/codecoverage/codecoverage.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rancherDynamic "github.com/rancher/shepherd/clients/dynamic"
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
@@ -17,7 +18,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
 )
 
 var podGroupVersionResource = corev1.SchemeGroupVersion.WithResource("pods")
@@ -30,7 +30,7 @@ const (
 	outputDir             = "cover"
 )
 
-func checkServiceIsRunning(dynamicClient dynamic.Interface) error {
+func checkServiceIsRunning(dynamicClient rancherDynamic.Client) error {
 	return kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
 		_, err = dynamicClient.Resource(podGroupVersionResource).Namespace(cattleSystemNameSpace).List(context.Background(), metav1.ListOptions{})
 		if k8sErrors.IsInternalError(err) || k8sErrors.IsServiceUnavailable(err) {
@@ -120,7 +120,7 @@ func KillRancherTestServicesRetrieveCoverage(client *rancher.Client) error {
 		return err
 	}
 
-	err = checkServiceIsRunning(dynamicClient)
+	err = checkServiceIsRunning(*dynamicClient)
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func KillAgentTestServicesRetrieveCoverage(client *rancher.Client) error {
 				return err
 			}
 
-			err = checkServiceIsRunning(dynamicClient)
+			err = checkServiceIsRunning(*dynamicClient)
 			if err != nil {
 				return err
 			}

--- a/extensions/kubeapi/cluster/operations.go
+++ b/extensions/kubeapi/cluster/operations.go
@@ -1,0 +1,34 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const ManagementGroupName = "management.cattle.io"
+
+func ManagementClusterGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: ManagementGroupName, Version: "v3", Resource: "clusters"}
+}
+
+// ListAll is a helper function that uses the dynamic client to return a list of all clusters.management.cattle.io.
+func ListAll(client *rancher.Client, opts *metav1.ListOptions) (list *unstructured.UnstructuredList, err error) {
+	if opts == nil {
+		opts = &metav1.ListOptions{}
+	}
+
+	dynamic, err := client.GetRancherDynamicClient()
+	if err != nil {
+		return
+	}
+
+	unstructuredClusterList, err := dynamic.Resource(ManagementClusterGVR()).List(context.TODO(), *opts)
+	if err != nil {
+		return
+	}
+	return unstructuredClusterList, err
+}

--- a/extensions/kubeapi/cluster/summary.go
+++ b/extensions/kubeapi/cluster/summary.go
@@ -6,7 +6,6 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/wrangler/pkg/summary"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // IsClusterActive is a helper function that uses the dynamic client to return cluster's ready state.
@@ -16,7 +15,7 @@ func IsClusterActive(client *rancher.Client, clusterID string) (ready bool, err 
 		return
 	}
 
-	unstructuredCluster, err := dynamic.Resource(schema.GroupVersionResource{Group: "management.cattle.io", Version: "v3", Resource: "clusters"}).Get(context.TODO(), clusterID, metav1.GetOptions{})
+	unstructuredCluster, err := dynamic.Resource(ManagementClusterGVR()).Get(context.TODO(), clusterID, metav1.GetOptions{})
 	if err != nil {
 		return
 	}

--- a/extensions/kubeapi/helm/helm.go
+++ b/extensions/kubeapi/helm/helm.go
@@ -45,7 +45,7 @@ func InstallRancher(ts *session.Session, restConfig *rest.Config) error {
 	}
 
 	// Install Rancher Chart
-	err = helm.InstallChart(ts, "rancher",
+	return helm.InstallChart(ts, "rancher",
 		"rancher-stable/rancher",
 		"cattle-system",
 		"",
@@ -57,11 +57,6 @@ func InstallRancher(ts *session.Session, restConfig *rest.Config) error {
 		"useBundledSystemChart=true",
 		"--set",
 		"replicas=1")
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // InstallCertManager installs latest version cert manager available through helm
@@ -87,10 +82,5 @@ func InstallCertManager(ts *session.Session, restConfig *rest.Config) error {
 	}
 
 	// Install cert-manager Chart
-	err = helm.InstallChart(ts, "cert-manager", "jetstack/cert-manager", "cert-manager", "", "--set", "installCRDs=true")
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return helm.InstallChart(ts, "cert-manager", "jetstack/cert-manager", "cert-manager", "", "--set", "installCRDs=true")
 }

--- a/extensions/kubeapi/rbac/list.go
+++ b/extensions/kubeapi/rbac/list.go
@@ -159,3 +159,28 @@ func ListRoleTemplates(client *rancher.Client, listOpt metav1.ListOptions) (*v3.
 
 	return rtList, nil
 }
+
+// ListProjectRoleTemplateBindings is a helper function that uses the dynamic client to list projectroletemplatebindings from local cluster.
+func ListProjectRoleTemplateBindings(client *rancher.Client, listOpt metav1.ListOptions) (*v3.ProjectRoleTemplateBindingList, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(LocalCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredList, err := dynamicClient.Resource(ProjectRoleTemplateBindingGroupVersionResource).Namespace("").List(context.TODO(), listOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	prtbList := new(v3.ProjectRoleTemplateBindingList)
+	for _, unstructuredPRTB := range unstructuredList.Items {
+		prtb := &v3.ProjectRoleTemplateBinding{}
+		err := scheme.Scheme.Convert(&unstructuredPRTB, prtb, unstructuredPRTB.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		prtbList.Items = append(prtbList.Items, *prtb)
+	}
+	return prtbList, nil
+}

--- a/extensions/kubeapi/workloads/deployments/get.go
+++ b/extensions/kubeapi/workloads/deployments/get.go
@@ -1,0 +1,33 @@
+package deployments
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/api/scheme"
+	appv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetDeployment is a helper function that uses the dynamic client to get a deployment in a cluster with its get options.
+func GetDeployment(client *rancher.Client, clusterID, name, namespace string, getOpts metav1.GetOptions) (*appv1.Deployment, error) {
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	deploymentResource := dynamicClient.Resource(DeploymentGroupVersionResource).Namespace(namespace)
+	unstructuredResp, err := deploymentResource.Get(context.TODO(), name, getOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	newDeployment := &appv1.Deployment{}
+	err = scheme.Scheme.Convert(unstructuredResp, newDeployment, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	return newDeployment, nil
+}

--- a/extensions/kubeapi/workloads/deployments/patch.go
+++ b/extensions/kubeapi/workloads/deployments/patch.go
@@ -1,0 +1,66 @@
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/api/scheme"
+	appv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func PatchDeployment(client *rancher.Client, clusterID, deploymentName, namespace string, data string, patchType types.PatchType) (*appv1.Deployment, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	deploymentResource := dynamicClient.Resource(DeploymentGroupVersionResource).Namespace(namespace)
+
+	unstructuredResp, err := deploymentResource.Patch(context.TODO(), deploymentName, patchType, []byte(data), metav1.PatchOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newDeployment := &appv1.Deployment{}
+	err = scheme.Scheme.Convert(unstructuredResp, newDeployment, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+	return newDeployment, nil
+}
+
+// PatchDeploymentFromYAML is a helper function that uses the dynamic client to patch a deployment in a namespace for a specific cluster.
+// Different merge strategies are supported based on the PatchType.
+func PatchDeploymentFromYAML(client *rancher.Client, clusterID, deploymentName, namespace string, rawYAML []byte, patchType types.PatchType) (*appv1.Deployment, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	deploymentResource := dynamicClient.Resource(DeploymentGroupVersionResource).Namespace(namespace)
+
+	rawJSON, err := yaml.ToJSON(rawYAML)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredResp, err := deploymentResource.Patch(context.TODO(), deploymentName, patchType, rawJSON, metav1.PatchOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newDeployment := &appv1.Deployment{}
+	err = scheme.Scheme.Convert(unstructuredResp, newDeployment, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+	return newDeployment, nil
+}
+
+func RestartDeployment(client *rancher.Client, clusterID, deploymentName, namespace string) (*appv1.Deployment, error) {
+	data := fmt.Sprintf(`{"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}}}`, time.Now().Format("20060102150405"))
+	return PatchDeploymentFromYAML(client, clusterID, deploymentName, namespace, []byte(data), types.StrategicMergePatchType)
+}

--- a/extensions/kubeconfig/exec.go
+++ b/extensions/kubeconfig/exec.go
@@ -2,6 +2,7 @@ package kubeconfig
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -73,7 +74,7 @@ func KubectlExec(restConfig *restclient.Config, podName, namespace string, comma
 	}
 
 	logStreamer := &LogStreamer{}
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
 		Stdin:  nil,
 		Stdout: logStreamer,
 		Stderr: os.Stderr,

--- a/extensions/kubeconfig/kubeconfig.go
+++ b/extensions/kubeconfig/kubeconfig.go
@@ -2,8 +2,10 @@ package kubeconfig
 
 import (
 	"errors"
+	"os"
 
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -32,4 +34,29 @@ func GetKubeconfig(client *rancher.Client, clusterID string) (*clientcmd.ClientC
 	}
 
 	return &cfg, nil
+}
+
+func WriteKubeconfigToFile(client *rancher.Client, clusterID, path string) error {
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	if err != nil {
+		return err
+	}
+
+	kubeConfig, err := client.Management.Cluster.ActionGenerateKubeconfig(cluster)
+	if err != nil {
+		return err
+	}
+
+	_, statErr := os.Stat(path)
+	if statErr == nil {
+		err = os.Remove(path)
+	}
+
+	if f, err := os.Create(path); err == nil {
+		if _, err := f.Write([]byte(kubeConfig.Config)); err != nil {
+			return err
+		}
+	}
+	logrus.Infof("Finished writing. Err: %v", err)
+	return err
 }

--- a/extensions/kubeconfig/kubeconfig.go
+++ b/extensions/kubeconfig/kubeconfig.go
@@ -4,9 +4,12 @@ import (
 	"errors"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 // GetKubeconfig generates a kubeconfig froma specific cluster, and returns it in the form of a *clientcmd.ClientConfig
@@ -34,6 +37,78 @@ func GetKubeconfig(client *rancher.Client, clusterID string) (*clientcmd.ClientC
 	}
 
 	return &cfg, nil
+}
+
+func GetKubeconfigFromFlags(masterURL, kubeconfigPath string) (*clientcmd.ClientConfig, error) {
+	if _, err := os.Stat(kubeconfigPath); err != nil {
+		return nil, errors.Wrap(err, "GetKubeconfigFromFlags: ")
+	}
+	kubeConfigContent, err := os.ReadFile(kubeconfigPath) //read the content of file
+	if err != nil {
+		return nil, err
+	}
+
+	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeConfigContent)
+	if err != nil {
+		return nil, err
+	}
+	if masterURL != "" {
+		rawConfig, err := clientConfig.RawConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		clientConfig = clientcmd.NewDefaultClientConfig(rawConfig, &clientcmd.ConfigOverrides{
+			ClusterInfo: api.Cluster{
+				Server: masterURL,
+			},
+		})
+	}
+	return &clientConfig, err
+}
+
+func GenerateKubeconfigForRestConfig(restConfig *rest.Config, defaultUser, defaultContext, clusterName string) ([]byte, error) {
+	if defaultUser == "" || defaultContext == "" || clusterName == "" {
+		return nil, errors.New("GenerateKubeconfigForRestConfig: 'defaultUser', 'defaultContext', and 'clusterName' must all be non-zero strings")
+	}
+	clusters := make(map[string]*api.Cluster)
+	clusters["default-cluster"] = &api.Cluster{
+		Server:                   restConfig.Host,
+		CertificateAuthorityData: restConfig.CAData,
+	}
+	contexts := make(map[string]*api.Context)
+	contexts["default-context"] = &api.Context{
+		Cluster:  clusterName,
+		AuthInfo: defaultUser,
+	}
+	authinfos := make(map[string]*api.AuthInfo)
+	authinfos["default-user"] = &api.AuthInfo{
+		ClientCertificateData: restConfig.CertData,
+		ClientKeyData:         restConfig.KeyData,
+	}
+	clientConfig := api.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       clusters,
+		Contexts:       contexts,
+		CurrentContext: defaultContext,
+		AuthInfos:      authinfos,
+	}
+	return clientcmd.Write(clientConfig)
+}
+
+func GetKubeConfigBytes(client *rancher.Client, clusterID string) ([]byte, error) {
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeConfig, err := client.Management.Cluster.ActionGenerateKubeconfig(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(kubeConfig.Config), err
 }
 
 func WriteKubeconfigToFile(client *rancher.Client, clusterID, path string) error {

--- a/extensions/kubeconfig/podlogs.go
+++ b/extensions/kubeconfig/podlogs.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 	"strings"
 
@@ -14,7 +16,9 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
-// GetPodLogs fetches logs from a Kubernetes pod. Buffer size (e.g., '64KB', '8MB', '1GB') influences log reading; an empty string causes no buffering.
+// GetPodLogs fetches logs from a Kubernetes pod
+// Buffer size (e.g., '64KB', '8MB', '1GB') influences log reading; an empty string results in bufio.Scanner's default of 4096 bytes
+// returns a string of all logs read and an error if any
 func GetPodLogs(client *rancher.Client, clusterID string, podName string, namespace string, bufferSizeStr string) (string, error) {
 	var restConfig *restclient.Config
 
@@ -73,10 +77,71 @@ func GetPodLogs(client *rancher.Client, clusterID string, podName string, namesp
 	return logs, nil
 }
 
+// GetPodLogsWithOpts fetches logs from a Kubernetes pod and allows
+// Buffer size (e.g., '64KB', '8MB', '1GB') influences log reading; an empty string results in bufio.Scanner's default of 4096 bytes
+// returns a string of all logs read and an error if any
+func GetPodLogsWithOpts(client *rancher.Client, clusterID string, podName string, namespace string, bufferSizeStr string, opts *corev1.PodLogOptions) (string, error) {
+	var restConfig *restclient.Config
+
+	kubeConfig, err := GetKubeconfig(client, clusterID)
+	if err != nil {
+		return "", err
+	}
+
+	restConfig, err = (*kubeConfig).ClientConfig()
+	if err != nil {
+		return "", err
+	}
+	restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(k8Scheme.Scheme)
+	restConfig.ContentConfig.GroupVersion = &podGroupVersion
+	restConfig.APIPath = apiPath
+
+	restClient, err := restclient.RESTClientFor(restConfig)
+	if err != nil {
+		return "", err
+	}
+
+	req := restClient.Get().Resource("pods").Name(podName).Namespace(namespace).SubResource("log")
+	req.VersionedParams(
+		opts,
+		k8Scheme.ParameterCodec,
+	)
+
+	stream, err := req.Stream(context.TODO())
+	if err != nil {
+		return "", fmt.Errorf("error streaming pod logs for pod %s/%s: %v", namespace, podName, err)
+	}
+
+	defer stream.Close()
+
+	reader := bufio.NewScanner(stream)
+
+	if bufferSizeStr != "" {
+		bufferSize, err := parseBufferSize(bufferSizeStr)
+		if err != nil {
+			return "", fmt.Errorf("error in parseBufferSize: %v", err)
+		}
+
+		buf := make([]byte, bufferSize)
+		reader.Buffer(buf, bufferSize)
+	}
+
+	var logs string
+	for reader.Scan() {
+		logs = logs + fmt.Sprintf("%s\n", reader.Text())
+		fmt.Println(reader.Text())
+	}
+
+	if err := reader.Err(); err != nil {
+		return "", fmt.Errorf("error reading pod logs for pod %s/%s: %v", namespace, podName, err)
+	}
+	return logs, nil
+}
+
 // parseBufferSize is a helper function that parses a size string and returns
 // the equivalent size in bytes. The provided size string should end with a
 // suffix of 'KB', 'MB', or 'GB'. If no suffix is provided, the function will
-// return an error.
+// return an int of the buffer size and an error if any
 func parseBufferSize(sizeStr string) (int, error) {
 	sizeStr = strings.ToUpper(sizeStr)
 	var mult int
@@ -100,4 +165,90 @@ func parseBufferSize(sizeStr string) (int, error) {
 	}
 
 	return size * mult, nil
+}
+
+// GetPodLogsWithContext fetches logs from a Kubernetes pod
+// Buffer size (e.g., '64KB', '8MB', '1GB') influences log reading; an empty string results in bufio.Scanner's default of 4096 bytes
+// returns a string of all logs read and an error if any
+func GetPodLogsWithContext(ctx context.Context, client *rancher.Client, clusterID, podName, namespace, bufferSizeStr, logFilePath string, opts *corev1.PodLogOptions) (string, error) {
+	var restConfig *restclient.Config
+
+	kubeConfig, err := GetKubeconfig(client, clusterID)
+	if err != nil {
+		return "", err
+	}
+
+	restConfig, err = (*kubeConfig).ClientConfig()
+	if err != nil {
+		return "", err
+	}
+	restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(k8Scheme.Scheme)
+	restConfig.ContentConfig.GroupVersion = &podGroupVersion
+	restConfig.APIPath = apiPath
+
+	restClient, err := restclient.RESTClientFor(restConfig)
+	if err != nil {
+		return "", err
+	}
+
+	req := restClient.Get().Resource("pods").Name(podName).Namespace(namespace).SubResource("log")
+	req.VersionedParams(
+		opts,
+		k8Scheme.ParameterCodec,
+	)
+
+	stream, err := req.Stream(context.Background())
+	if err != nil {
+		return "", fmt.Errorf("error streaming pod logs for pod %s/%s: %v", namespace, podName, err)
+	}
+	defer stream.Close()
+
+	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return "", fmt.Errorf("error opening log file: %v", err)
+	}
+	defer logFile.Close()
+
+	return readAndWriteLogsWithContext(ctx, stream, logFile, bufferSizeStr)
+}
+
+// readAndWriteLogsWithContext is a helper function that reads and writes text to console output and the specific logFile using a channel
+//   - filters out log lines containing "debug"
+//   - if the context is canceled before all logs are read, the function returns immediately with the logs read so far and the context's error
+//
+// Buffer size (e.g., '64KB', '8MB', '1GB') influences log reading; an empty string results in bufio.Scanner's default of 4096 bytes
+// returns a string of all logs read and an error if any
+func readAndWriteLogsWithContext(ctx context.Context, stream io.ReadCloser, logFile *os.File, bufferSizeStr string) (string, error) {
+	logs := &strings.Builder{}
+	defer logFile.Close()
+
+	scanner := bufio.NewScanner(stream)
+	if bufferSizeStr != "" {
+		bufferSize, err := parseBufferSize(bufferSizeStr)
+		if err != nil {
+			return "", fmt.Errorf("error in parseBufferSize: %v", err)
+		}
+
+		buf := make([]byte, bufferSize)
+		scanner.Buffer(buf, bufferSize)
+	}
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return logs.String(), ctx.Err() // Return immediately if context is canceled
+		default:
+			logLine := scanner.Text()
+			if !strings.Contains(strings.ToLower(logLine), "debug") && strings.TrimSpace(logLine) != "" {
+				fmt.Println(logLine) // Write log to stdout
+			}
+			fmt.Fprintln(logFile, logLine) // Write log to file
+			logs.WriteString(logLine + "\n")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return logs.String(), fmt.Errorf("error reading logs: %v", err)
+	}
+
+	return logs.String(), nil
 }

--- a/extensions/kubeconfig/pods.go
+++ b/extensions/kubeconfig/pods.go
@@ -1,0 +1,57 @@
+package kubeconfig
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+	k8Scheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+func GetPods(client *rancher.Client, clusterID string, namespace string, listOptions *metav1.ListOptions) ([]corev1.Pod, error) {
+
+	kubeConfig, err := GetKubeconfig(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(k8Scheme.Scheme)
+	restConfig.ContentConfig.GroupVersion = &podGroupVersion
+	restConfig.APIPath = apiPath
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), *listOptions)
+	if err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
+}
+
+func GetPodNames(client *rancher.Client, clusterID string, namespace string, listOptions *metav1.ListOptions) ([]string, error) {
+	pods, err := GetPods(client, clusterID, namespace, listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	if len(names) == 0 {
+		return nil, errors.New("GetPodNames: no pod names found")
+	}
+
+	return names, nil
+}

--- a/extensions/kubectl/create.go
+++ b/extensions/kubectl/create.go
@@ -1,0 +1,54 @@
+package kubectl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/unstructured"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1Unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func CreateUnstructured(s *session.Session, client *rancher.Client, content []byte, clusterID, n string, gvr schema.GroupVersionResource) (*v1Unstructured.Unstructured, error) {
+	dynClient, _, err := setupDynamicClient(s, client, nil, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	obj, _, err := v1Unstructured.UnstructuredJSONScheme.Decode(content, nil, nil)
+	if err != nil {
+		logrus.Fatal(fmt.Sprintf("Error while decoding YAML object. Err was: %s", err))
+		return nil, err
+	}
+
+	result, err := dynClient.Resource(gvr).Namespace(n).Create(context.TODO(), unstructured.MustToUnstructured(obj), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func CreateUnstructuredFromFlags(s *session.Session, masterURL, kubeconfigPath string, content []byte, n string, gvr schema.GroupVersionResource) (*v1Unstructured.Unstructured, error) {
+	dynClient, _, err := setupDynamicClientFromFlags(s, masterURL, kubeconfigPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	obj, _, err := v1Unstructured.UnstructuredJSONScheme.Decode(content, nil, nil)
+	if err != nil {
+		logrus.Fatal(fmt.Sprintf("Error while decoding YAML object. Err was: %s", err))
+		return nil, err
+	}
+
+	result, err := dynClient.Resource(gvr).Namespace(n).Create(context.TODO(), unstructured.MustToUnstructured(obj), metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/extensions/kubectl/get.go
+++ b/extensions/kubectl/get.go
@@ -1,0 +1,39 @@
+package kubectl
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/session"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1Unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func GetUnstructured(s *session.Session, client *rancher.Client, name, clusterID, n string, gvr schema.GroupVersionResource) (*v1Unstructured.Unstructured, error) {
+	dynClient, _, err := setupDynamicClient(s, client, nil, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := dynClient.Resource(gvr).Namespace(n).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func GetUnstructuredFromFlags(s *session.Session, masterURL, kubeconfigPath, name, clusterID, n string, gvr schema.GroupVersionResource) (*v1Unstructured.Unstructured, error) {
+	dynClient, _, err := setupDynamicClientFromFlags(s, masterURL, kubeconfigPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := dynClient.Resource(gvr).Namespace(n).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/extensions/kubectl/list.go
+++ b/extensions/kubectl/list.go
@@ -1,0 +1,65 @@
+package kubectl
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/session"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1Unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func ListUnstructured(s *session.Session, client *rancher.Client, name, clusterID, n string, gvr schema.GroupVersionResource, opts metav1.ListOptions) (*v1Unstructured.UnstructuredList, error) {
+	dynClient, _, err := setupDynamicClient(s, client, nil, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := dynClient.Resource(gvr).Namespace(n).List(context.TODO(), opts)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func ListAllUnstructured(s *session.Session, client *rancher.Client, name, clusterID string, gvr schema.GroupVersionResource, opts metav1.ListOptions) (*v1Unstructured.UnstructuredList, error) {
+	dynClient, _, err := setupDynamicClient(s, client, nil, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := dynClient.Resource(gvr).List(context.TODO(), opts)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func ListUnstructuredFromFlags(s *session.Session, masterURL, kubeconfigPath, name, clusterID, n string, gvr schema.GroupVersionResource, opts metav1.ListOptions) (*v1Unstructured.UnstructuredList, error) {
+	dynClient, _, err := setupDynamicClientFromFlags(s, masterURL, kubeconfigPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := dynClient.Resource(gvr).Namespace(n).List(context.TODO(), opts)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func ListAllUnstructuredFromFlags(s *session.Session, masterURL, kubeconfigPath, name, clusterID string, gvr schema.GroupVersionResource, opts metav1.ListOptions) (*v1Unstructured.UnstructuredList, error) {
+	dynClient, _, err := setupDynamicClientFromFlags(s, masterURL, kubeconfigPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := dynClient.Resource(gvr).List(context.TODO(), opts)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/extensions/kubectl/setup.go
+++ b/extensions/kubectl/setup.go
@@ -1,0 +1,65 @@
+package kubectl
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/kubeconfig"
+	"github.com/rancher/shepherd/pkg/session"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	shepherdDynamic "github.com/rancher/shepherd/clients/dynamic"
+)
+
+func setupDynamicClient(s *session.Session, client *rancher.Client, scheme *runtime.Scheme, clusterID string) (*shepherdDynamic.Client, *session.Session, error) {
+	kubeConfig, err := kubeconfig.GetKubeconfig(client, clusterID)
+	if err != nil {
+		return nil, s, err
+	}
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	if err != nil {
+		return nil, s, err
+	}
+
+	if scheme != nil {
+		restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme)
+	}
+
+	var session *session.Session
+	if s == nil {
+		session = client.Session.NewSession()
+	} else {
+		session = s
+	}
+
+	dynClient, err := shepherdDynamic.NewForConfig(session, restConfig)
+
+	return dynClient, session, err
+}
+
+func setupDynamicClientFromFlags(s *session.Session, masterURL, kubeconfigPath string, scheme *runtime.Scheme) (*shepherdDynamic.Client, *session.Session, error) {
+	kubeConfig, err := kubeconfig.GetKubeconfigFromFlags(masterURL, kubeconfigPath)
+	if err != nil {
+		return nil, s, err
+	}
+
+	restConfig, err := (*kubeConfig).ClientConfig()
+	if err != nil {
+		return nil, s, err
+	}
+
+	if scheme != nil {
+		restConfig.ContentConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme)
+	}
+
+	var session *session.Session
+	if s == nil {
+		session = session.NewSession()
+	} else {
+		session = s
+	}
+
+	dynClient, err := shepherdDynamic.NewForConfig(session, restConfig)
+
+	return dynClient, session, err
+}

--- a/extensions/provisioning/verify.go
+++ b/extensions/provisioning/verify.go
@@ -103,6 +103,65 @@ func VerifyRKE1Cluster(t *testing.T, client *rancher.Client, clustersConfig *clu
 	}
 }
 
+// VerifyRKE1ClusterWithTimeout validates that the RKE1 cluster and its resources are in a good state within the custom timeout, matching a given config.
+func VerifyRKE1ClusterWithTimeout(t *testing.T, client *rancher.Client, clustersConfig *clusters.ClusterConfig, cluster *management.Cluster, timeout *int64) {
+	client, err := client.ReLogin()
+	require.NoError(t, err)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+
+	var timeoutSeconds *int64
+	if timeout != nil {
+		timeoutSeconds = timeout
+	} else {
+		timeoutSeconds = &defaults.WatchTimeoutSeconds
+	}
+
+	watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + cluster.ID,
+		TimeoutSeconds: timeoutSeconds,
+	})
+	require.NoError(t, err)
+
+	checkFunc := clusters.IsHostedProvisioningClusterReady
+	err = wait.WatchWait(watchInterface, checkFunc)
+	require.NoError(t, err)
+
+	assert.Equal(t, clustersConfig.KubernetesVersion, cluster.RancherKubernetesEngineConfig.Version)
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, cluster.Name)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clusterToken)
+
+	err = nodestat.AllManagementNodeReady(client, cluster.ID, defaults.ThirtyMinuteTimeout)
+	require.NoError(t, err)
+
+	if clustersConfig.PSACT == string(provisioninginput.RancherPrivileged) || clustersConfig.PSACT == string(provisioninginput.RancherRestricted) || clustersConfig.PSACT == string(provisioninginput.RancherBaseline) {
+		require.NotEmpty(t, cluster.DefaultPodSecurityAdmissionConfigurationTemplateName)
+
+		err := psadeploy.CreateNginxDeployment(client, cluster.ID, clustersConfig.PSACT)
+		require.NoError(t, err)
+	}
+	if clustersConfig.Registries != nil {
+		if clustersConfig.Registries.RKE1Registries != nil {
+			for _, registry := range clustersConfig.Registries.RKE1Registries {
+				havePrefix, err := registries.CheckAllClusterPodsForRegistryPrefix(client, cluster.ID, registry.URL)
+				require.NoError(t, err)
+				assert.True(t, havePrefix)
+			}
+		}
+	}
+	if clustersConfig.Networking != nil {
+		if clustersConfig.Networking.LocalClusterAuthEndpoint != nil {
+			VerifyACE(t, adminClient, cluster)
+		}
+	}
+
+	podErrors := pods.StatusPods(client, cluster.ID)
+	assert.Empty(t, podErrors)
+}
+
 // VerifyCluster validates that a non-rke1 cluster and its resources are in a good state, matching a given config.
 func VerifyCluster(t *testing.T, client *rancher.Client, clustersConfig *clusters.ClusterConfig, cluster *steveV1.SteveAPIObject) {
 	client, err := client.ReLogin()
@@ -176,6 +235,84 @@ func VerifyCluster(t *testing.T, client *rancher.Client, clustersConfig *cluster
 	}
 }
 
+// VerifyClusterWithTimeout validates that a non-rke1 cluster and its resources are in a good state within the custom timeout, matching a given config.
+func VerifyClusterWithTimeout(t *testing.T, client *rancher.Client, clustersConfig *clusters.ClusterConfig, cluster *steveV1.SteveAPIObject, timeout *int64) {
+	client, err := client.ReLogin()
+	require.NoError(t, err)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+
+	kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
+	require.NoError(t, err)
+
+	var timeoutSeconds *int64
+	if timeout != nil {
+		timeoutSeconds = timeout
+	} else {
+		timeoutSeconds = &defaults.WatchTimeoutSeconds
+	}
+
+	watchInterface, err := kubeProvisioningClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + cluster.Name,
+		TimeoutSeconds: timeoutSeconds,
+	})
+	require.NoError(t, err)
+
+	checkFunc := clusters.IsProvisioningClusterReady
+	err = wait.WatchWait(watchInterface, checkFunc)
+	require.NoError(t, err)
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, cluster.Name)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clusterToken)
+
+	err = nodestat.AllMachineReady(client, cluster.ID, defaults.ThirtyMinuteTimeout)
+	require.NoError(t, err)
+
+	status := &provv1.ClusterStatus{}
+	err = steveV1.ConvertToK8sType(cluster.Status, status)
+	require.NoError(t, err)
+
+	clusterSpec := &provv1.ClusterSpec{}
+	err = steveV1.ConvertToK8sType(cluster.Spec, clusterSpec)
+	require.NoError(t, err)
+
+	configKubeVersion := clusterSpec.KubernetesVersion
+	require.Equal(t, configKubeVersion, clusterSpec.KubernetesVersion)
+
+	if clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName == string(provisioninginput.RancherPrivileged) ||
+		clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName == string(provisioninginput.RancherRestricted) ||
+		clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName == string(provisioninginput.RancherBaseline) {
+
+		require.NotEmpty(t, clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName)
+
+		err := psadeploy.CreateNginxDeployment(client, status.ClusterName, clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName)
+		require.NoError(t, err)
+	}
+
+	if clusterSpec.RKEConfig.Registries != nil {
+		for registryName := range clusterSpec.RKEConfig.Registries.Configs {
+			havePrefix, err := registries.CheckAllClusterPodsForRegistryPrefix(client, status.ClusterName, registryName)
+			require.NoError(t, err)
+			assert.True(t, havePrefix)
+		}
+	}
+
+	if clusterSpec.LocalClusterAuthEndpoint.Enabled {
+		mgmtClusterObject, err := adminClient.Management.Cluster.ByID(status.ClusterName)
+		require.NoError(t, err)
+		VerifyACE(t, adminClient, mgmtClusterObject)
+	}
+
+	podErrors := pods.StatusPods(client, status.ClusterName)
+	assert.Empty(t, podErrors)
+
+	if clustersConfig.ClusterSSHTests != nil {
+		VerifySSHTests(t, client, cluster, clustersConfig.ClusterSSHTests, status.ClusterName)
+	}
+}
+
 // VerifyHostedCluster validates that the hosted cluster and its resources are in a good state, matching a given config.
 func VerifyHostedCluster(t *testing.T, client *rancher.Client, cluster *management.Cluster) {
 	client, err := client.ReLogin()
@@ -187,6 +324,43 @@ func VerifyHostedCluster(t *testing.T, client *rancher.Client, cluster *manageme
 	watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, metav1.ListOptions{
 		FieldSelector:  "metadata.name=" + cluster.ID,
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(t, err)
+
+	checkFunc := clusters.IsHostedProvisioningClusterReady
+
+	err = wait.WatchWait(watchInterface, checkFunc)
+	require.NoError(t, err)
+
+	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, cluster.Name)
+	require.NoError(t, err)
+	assert.NotEmpty(t, clusterToken)
+
+	err = nodestat.AllManagementNodeReady(client, cluster.ID, defaults.ThirtyMinuteTimeout)
+	require.NoError(t, err)
+
+	podErrors := pods.StatusPods(client, cluster.ID)
+	assert.Empty(t, podErrors)
+}
+
+// VerifyHostedClusterWithTimeout validates that the hosted cluster and its resources are in a good state within the custom timeout, matching a given config.
+func VerifyHostedClusterWithTimeout(t *testing.T, client *rancher.Client, cluster *management.Cluster, timeout *int64) {
+	client, err := client.ReLogin()
+	require.NoError(t, err)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+
+	var timeoutSeconds *int64
+	if timeout != nil {
+		timeoutSeconds = timeout
+	} else {
+		timeoutSeconds = &defaults.WatchTimeoutSeconds
+	}
+
+	watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + cluster.ID,
+		TimeoutSeconds: timeoutSeconds,
 	})
 	require.NoError(t, err)
 
@@ -235,6 +409,42 @@ func VerifyDeleteRKE1Cluster(t *testing.T, client *rancher.Client, clusterID str
 	require.NoError(t, err)
 }
 
+// VerifyDeleteRKE1Cluster validates that a rke1 cluster and its resources are deleted.
+func VerifyDeleteRKE1ClusterWithTimeout(t *testing.T, client *rancher.Client, clusterID string, timeout *int64) {
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	require.NoError(t, err)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+
+	var timeoutSeconds *int64
+	if timeout != nil {
+		timeoutSeconds = timeout
+	} else {
+		timeoutSeconds = &defaults.WatchTimeoutSeconds
+	}
+
+	watchInterface, err := adminClient.GetManagementWatchInterface(management.ClusterType, metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + clusterID,
+		TimeoutSeconds: timeoutSeconds,
+	})
+	require.NoError(t, err)
+
+	err = wait.WatchWait(watchInterface, func(event watch.Event) (ready bool, err error) {
+		if event.Type == watch.Error {
+			return false, fmt.Errorf("error: unable to delete cluster %s", cluster.Name)
+		} else if event.Type == watch.Deleted {
+			logrus.Infof("Cluster %s deleted!", cluster.Name)
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	err = nodestat.AllNodeDeleted(client, clusterID)
+	require.NoError(t, err)
+}
+
 // VerifyDeleteRKE2K3SCluster validates that a non-rke1 cluster and its resources are deleted.
 func VerifyDeleteRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterID string) {
 	cluster, err := client.Steve.SteveType("provisioning.cattle.io.cluster").ByID(clusterID)
@@ -249,6 +459,49 @@ func VerifyDeleteRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterID 
 	watchInterface, err := provKubeClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
 		FieldSelector:  "metadata.name=" + cluster.Name,
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	require.NoError(t, err)
+
+	err = wait.WatchWait(watchInterface, func(event watch.Event) (ready bool, err error) {
+		cluster := event.Object.(*provv1.Cluster)
+		if event.Type == watch.Error {
+			return false, fmt.Errorf("error: unable to delete cluster %s", cluster.ObjectMeta.Name)
+		} else if event.Type == watch.Deleted {
+			logrus.Infof("Cluster %s deleted!", cluster.ObjectMeta.Name)
+			return true, nil
+		} else if cluster == nil {
+			logrus.Infof("Cluster %s deleted!", cluster.ObjectMeta.Name)
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+	err = nodestat.AllNodeDeleted(client, clusterID)
+	require.NoError(t, err)
+}
+
+// VerifyDeleteRKE2K3SClusterWithTimeout validates that a non-rke1 cluster and its resources are deleted.
+func VerifyDeleteRKE2K3SClusterWithTimeout(t *testing.T, client *rancher.Client, clusterID string, timeout *int64) {
+	cluster, err := client.Steve.SteveType("provisioning.cattle.io.cluster").ByID(clusterID)
+	require.NoError(t, err)
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	require.NoError(t, err)
+
+	provKubeClient, err := adminClient.GetKubeAPIProvisioningClient()
+	require.NoError(t, err)
+
+	var timeoutSeconds *int64
+	if timeout != nil {
+		timeoutSeconds = timeout
+	} else {
+		timeoutSeconds = &defaults.WatchTimeoutSeconds
+	}
+
+	watchInterface, err := provKubeClient.Clusters(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + cluster.Name,
+		TimeoutSeconds: timeoutSeconds,
 	})
 	require.NoError(t, err)
 
@@ -461,6 +714,26 @@ func VerifySnapshots(client *rancher.Client, clusterName string, expectedSnapsho
 		return false, nil
 	})
 	return snapshotToBeRestored, err
+}
+
+// getSnapshots is a helper function to get the snapshots for a cluster
+func GetSnapshots(client *rancher.Client, localclusterID string, clusterName string) ([]string, error) {
+	steveclient, err := client.Steve.ProxyDownstream(localclusterID)
+	if err != nil {
+		return nil, err
+	}
+	snapshotSteveObjList, err := steveclient.SteveType("rke.cattle.io.etcdsnapshot").List(nil)
+	if err != nil {
+		return nil, err
+	}
+	snapshots := []string{}
+	for _, snapshot := range snapshotSteveObjList.Data {
+		if strings.Contains(snapshot.ObjectMeta.Name, clusterName) {
+			snapshots = append(snapshots, snapshot.Name)
+		}
+	}
+	return snapshots, nil
+
 }
 
 // VerifySSHTests validates the ssh tests listed in the config on each node of the cluster


### PR DESCRIPTION
Depends on: 
  - PR #81 
  - PR #31 
  - PR #30 
  - PR #29 
  - PR #27 

Changes: 
- Some minor updates to helm client
- Added unstructured create, get, list, update to kubectl extension
- Refactored kubectl extension's `setup.go` slightly
- Update .golangci.yaml to ignore podlogs.go fmt.Println call since it is intended
  - Should this also be made into a "log" call instead?