### PR TITLE
Add ability to provide replicas in the deployment spec

### DIFF
--- a/extensions/kubeapi/workloads/deployments/create.go
+++ b/extensions/kubeapi/workloads/deployments/create.go
@@ -22,7 +22,7 @@ var DeploymentGroupVersionResource = schema.GroupVersionResource{
 }
 
 // CreateDeployment is a helper function that uses the dynamic client to create a deployment on a namespace for a specific cluster.
-func CreateDeployment(client *rancher.Client, clusterName, deploymentName, namespace string, template corev1.PodTemplateSpec) (*appv1.Deployment, error) {
+func CreateDeployment(client *rancher.Client, clusterName, deploymentName, namespace string, template corev1.PodTemplateSpec, replicas int32) (*appv1.Deployment, error) {
 	dynamicClient, err := client.GetDownStreamClusterClient(clusterName)
 	if err != nil {
 		return nil, err
@@ -42,6 +42,7 @@ func CreateDeployment(client *rancher.Client, clusterName, deploymentName, names
 			Namespace: namespace,
 		},
 		Spec: appv1.DeploymentSpec{
+			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},


### PR DESCRIPTION
Currently, we cannot provide the replica count when creating a deployment using kube api. As part of this PR, I'm modifying '`CreateDeployment`' function under kubeapi to accept number of replicas. 
Note: 
- This function is not being used by any existing tests so modifying it won't break any tests.
- This PR requires a back port in 2.7 and 2.8.
  - Backport 2.7: https://github.com/rancher/shepherd/pull/85
  - Backport 2.8: https://github.com/rancher/shepherd/pull/86 