### PR TITLE
Create/Update kubeapi extensions - Deployment, Namespaces, Pods, LimitRange

### DIFF
--- a/extensions/kubeapi/limitranges/list.go
+++ b/extensions/kubeapi/limitranges/list.go
@@ -1,0 +1,52 @@
+package limitranges
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/api/scheme"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// LimitRangeGroupVersionResource is the required Group Version Resource for accessing limit ranges in a cluster,
+// using the dynamic client.
+var LimitRangeGroupVersionResource = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "limitranges",
+}
+
+// LimitRangeList is a struct that contains a list of resource quotas.
+type LimitRangeList struct {
+	Items []corev1.LimitRange
+}
+
+// ListLimitRange is a helper function that uses the dynamic client to list limit range in a cluster with its list options.
+func ListLimitRange(client *rancher.Client, clusterID string, namespace string, listOpts metav1.ListOptions) (*LimitRangeList, error) {
+	limitRangeList := new(LimitRangeList)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	limitRangeResource := dynamicClient.Resource(LimitRangeGroupVersionResource).Namespace(namespace)
+	limitRange, err := limitRangeResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, unstructuredLimitRange := range limitRange.Items {
+		newlimitRange := &corev1.LimitRange{}
+		err := scheme.Scheme.Convert(&unstructuredLimitRange, newlimitRange, unstructuredLimitRange.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		limitRangeList.Items = append(limitRangeList.Items, *newlimitRange)
+	}
+
+	return limitRangeList, nil
+}

--- a/extensions/kubeapi/namespaces/update.go
+++ b/extensions/kubeapi/namespaces/update.go
@@ -1,0 +1,47 @@
+package namespaces
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/unstructured"
+	"github.com/rancher/shepherd/pkg/api/scheme"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// UpdateNamespace is a helper function that uses the dynamic client to update a namespace.
+func UpdateNamespace(client *rancher.Client, clusterID string, updatedNamespace *coreV1.Namespace) (*coreV1.Namespace, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceResource := dynamicClient.Resource(NamespaceGroupVersionResource).Namespace("")
+
+	namespaceUnstructured, err := namespaceResource.Get(context.TODO(), updatedNamespace.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	currentNamespace := &coreV1.Namespace{}
+	err = scheme.Scheme.Convert(namespaceUnstructured, currentNamespace, namespaceUnstructured.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	updatedNamespace.ObjectMeta.ResourceVersion = currentNamespace.ObjectMeta.ResourceVersion
+
+	unstructuredResp, err := namespaceResource.Update(context.TODO(), unstructured.MustToUnstructured(updatedNamespace), metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newNamespace := &coreV1.Namespace{}
+	err = scheme.Scheme.Convert(unstructuredResp, newNamespace, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	return newNamespace, nil
+}

--- a/extensions/kubeapi/workloads/deployments/delete.go
+++ b/extensions/kubeapi/workloads/deployments/delete.go
@@ -1,0 +1,49 @@
+package deployments
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DeleteDeployment is a helper function that uses the dynamic client to delete a deployment in a namespace for a specific cluster.
+func DeleteDeployment(client *rancher.Client, clusterID string, namespaceName string, deploymentName string) error {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return err
+	}
+
+	deploymentResource := dynamicClient.Resource(DeploymentGroupVersionResource).Namespace(namespaceName)
+
+	err = deploymentResource.Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.OneMinuteTimeout)
+	defer cancel()
+
+	err = kwait.PollUntilContextCancel(ctx, defaults.FiveHundredMillisecondTimeout, false, func(ctx context.Context) (done bool, err error) {
+		deploymentList, err := ListDeployments(client, clusterID, namespaceName, metav1.ListOptions{
+			FieldSelector: "metadata.name=" + deploymentName,
+		})
+		if err != nil {
+			return false, err
+		}
+
+		if len(deploymentList.Items) == 0 {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/extensions/kubeapi/workloads/deployments/update.go
+++ b/extensions/kubeapi/workloads/deployments/update.go
@@ -1,0 +1,47 @@
+package deployments
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/unstructured"
+	"github.com/rancher/shepherd/pkg/api/scheme"
+	appv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// UpdateDeployment is a helper function that uses the dynamic client to update a deployment in a namespace for a specific cluster.
+func UpdateDeployment(client *rancher.Client, clusterID string, namespaceName string, updatedDeployment *appv1.Deployment) (*appv1.Deployment, error) {
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	deploymentResource := dynamicClient.Resource(DeploymentGroupVersionResource).Namespace(namespaceName)
+
+	deploymentUnstructured, err := deploymentResource.Get(context.TODO(), updatedDeployment.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	currentDeployment := &appv1.Deployment{}
+	err = scheme.Scheme.Convert(deploymentUnstructured, currentDeployment, deploymentUnstructured.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	updatedDeployment.ObjectMeta.ResourceVersion = currentDeployment.ObjectMeta.ResourceVersion
+
+	unstructuredResp, err := deploymentResource.Update(context.TODO(), unstructured.MustToUnstructured(updatedDeployment), metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	newDeployment := &appv1.Deployment{}
+	err = scheme.Scheme.Convert(unstructuredResp, newDeployment, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	return newDeployment, nil
+}

--- a/extensions/kubeapi/workloads/pods/list.go
+++ b/extensions/kubeapi/workloads/pods/list.go
@@ -1,0 +1,54 @@
+package pods
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/api/scheme"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodList is a struct that contains a list of deployments.
+type PodList struct {
+	Items []corev1.Pod
+}
+
+// ListPods is a helper function that uses the dynamic client to list pods on a namespace for a specific cluster with its list options.
+func ListPods(client *rancher.Client, clusterID string, namespace string, listOpts metav1.ListOptions) (*PodList, error) {
+	podList := new(PodList)
+
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	podResource := dynamicClient.Resource(PodGroupVersionResource).Namespace(namespace)
+	pods, err := podResource.List(context.TODO(), listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, unstructuredPod := range pods.Items {
+		newPod := &corev1.Pod{}
+		err := scheme.Scheme.Convert(&unstructuredPod, newPod, unstructuredPod.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		podList.Items = append(podList.Items, *newPod)
+	}
+
+	return podList, nil
+}
+
+// Names is a method that accepts PodList as a receiver,
+// returns each pod name in the list as a new slice of strings.
+func (list *PodList) Names() []string {
+	var podNames []string
+
+	for _, pod := range list.Items {
+		podNames = append(podNames, pod.Name)
+	}
+
+	return podNames
+}


### PR DESCRIPTION
Following extensions using kube API don't exist and are required to automate some of the P0 checks for Projects:
- [x] Update Namespace using K8s API
- [x] List Limit Range using K8s API
- [x] Delete Deployment using K8s API
- [x] Update Deployment using K8s API
- [x] List Pods using K8s API

**Note:** 
- Following PR needs to get merged before this PR: https://github.com/rancher/shepherd/pull/110
- **QA Tasks:**
  - https://github.com/rancher/qa-tasks/issues/1167
  - https://github.com/rancher/qa-tasks/issues/1235
- Once this gets approved, backports for 2.7 and 2.8 will be created.