### PR TITLE
[2.7] Update RKE1 nodetemplates v2.7

### DIFF
--- a/extensions/rke1/nodetemplates/aws/create.go
+++ b/extensions/rke1/nodetemplates/aws/create.go
@@ -1,6 +1,7 @@
 package nodetemplates
 
 import (
+	"github.com/imdario/mergo"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
@@ -24,13 +25,13 @@ func CreateAWSNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.NodeTe
 	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
 	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
 
-	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey)
+	err := mergo.Merge(&nodeTemplate, nodeTemplateConfig, mergo.WithOverride)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := &nodetemplates.NodeTemplate{}
-	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/rke1/nodetemplates/azure/create.go
+++ b/extensions/rke1/nodetemplates/azure/create.go
@@ -1,6 +1,7 @@
 package nodetemplates
 
 import (
+	"dario.cat/mergo"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
@@ -24,13 +25,13 @@ func CreateAzureNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.Node
 	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
 	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
 
-	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AzureNodeTemplateConfigurationFileKey)
+	err := mergo.Merge(&nodeTemplate, nodeTemplateConfig, mergo.WithOverride)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := &nodetemplates.NodeTemplate{}
-	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/rke1/nodetemplates/harvester/create.go
+++ b/extensions/rke1/nodetemplates/harvester/create.go
@@ -1,6 +1,7 @@
 package nodetemplates
 
 import (
+	"dario.cat/mergo"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
@@ -24,13 +25,13 @@ func CreateHarvesterNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.
 	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
 	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
 
-	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.HarvesterNodeTemplateConfigurationFileKey)
+	err := mergo.Merge(&nodeTemplate, nodeTemplateConfig, mergo.WithOverride)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := &nodetemplates.NodeTemplate{}
-	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/rke1/nodetemplates/linode/create.go
+++ b/extensions/rke1/nodetemplates/linode/create.go
@@ -1,6 +1,7 @@
 package nodetemplates
 
 import (
+	"dario.cat/mergo"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
@@ -24,13 +25,13 @@ func CreateLinodeNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.Nod
 	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
 	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
 
-	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.LinodeNodeTemplateConfigurationFileKey)
+	err := mergo.Merge(&nodeTemplate, nodeTemplateConfig, mergo.WithOverride)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := &nodetemplates.NodeTemplate{}
-	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/rke1/nodetemplates/vsphere/create.go
+++ b/extensions/rke1/nodetemplates/vsphere/create.go
@@ -1,6 +1,7 @@
 package nodetemplates
 
 import (
+	"dario.cat/mergo"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
@@ -24,13 +25,13 @@ func CreateVSphereNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.No
 	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
 	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
 
-	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.VmwareVsphereNodeTemplateConfigurationFileKey)
+	err := mergo.Merge(&nodeTemplate, nodeTemplateConfig, mergo.WithOverride)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := &nodetemplates.NodeTemplate{}
-	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, *nodeTemplateFinal, resp)
+	err = rancherClient.Management.APIBaseClient.Ops.DoCreate(management.NodeTemplateType, nodeTemplate, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ replace (
 )
 
 require (
+	dario.cat/mergo v1.0.0
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/aws/aws-sdk-go v1.44.322
 	github.com/creasty/defaults v1.5.2
@@ -22,6 +23,7 @@ require (
 	github.com/hashicorp/hc-install v0.5.2
 	github.com/hashicorp/terraform-exec v0.18.1
 	github.com/hashicorp/terraform-json v0.17.1
+	github.com/imdario/mergo v0.3.15
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.5
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.52.0
@@ -105,7 +107,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
-	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 contrib.go.opencensus.io/exporter/ocagent v0.6.0/go.mod h1:zmKjrJcdo0aYcVS7bmEeSEBLPA9YJp5bjrofdU3pIXs=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=


### PR DESCRIPTION
Remove custom MergeOverride() function due to incompatibility with golang v1.21. Replace with mergo.Merge() with override flag