### PR TITLE
[v2.7] Convert flaky Python CLI tests to the Go

### DIFF
--- a/clients/rancher/client.go
+++ b/clients/rancher/client.go
@@ -17,6 +17,7 @@ import (
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 
 	kubeProvisioning "github.com/rancher/shepherd/clients/provisioning"
+	"github.com/rancher/shepherd/clients/ranchercli"
 	kubeRKE "github.com/rancher/shepherd/clients/rke"
 	"github.com/rancher/shepherd/pkg/clientbase"
 	"github.com/rancher/shepherd/pkg/config"
@@ -41,6 +42,8 @@ type Client struct {
 	Catalog *catalog.Client
 	// Config used to test against a rancher instance
 	RancherConfig *Config
+	// CLI is the client used to interact with the Rancher CLI
+	CLI *ranchercli.Client
 	// Session is the session object used by the client to track all the resources being created by the client.
 	Session *session.Session
 	// Flags is the environment flags used by the client to test selectively against a rancher instance.
@@ -85,6 +88,13 @@ func NewClient(bearerToken string, session *session.Session) (*Client, error) {
 	}
 
 	c.Steve.Ops.Session = session
+
+	if rancherConfig.RancherCLI {
+		c.CLI, err = ranchercli.NewClient(session, bearerToken, rancherConfig.Host, c.Management)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	catalogClient, err := catalog.NewForConfig(restConfig, session)
 	if err != nil {

--- a/clients/rancher/config.go
+++ b/clients/rancher/config.go
@@ -14,4 +14,5 @@ type Config struct {
 	CACerts       string `yaml:"caCerts" json:"caCerts" default:""`
 	ClusterName   string `yaml:"clusterName" json:"clusterName" default:""`
 	ShellImage    string `yaml:"shellImage" json:"shellImage" default:""`
+	RancherCLI    bool   `yaml:"rancherCLI" json:"rancherCLI" default:"false"`
 }

--- a/clients/ranchercli/client.go
+++ b/clients/ranchercli/client.go
@@ -1,0 +1,95 @@
+package ranchercli
+
+import (
+	"fmt"
+	"os/exec"
+
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	rancher   = "rancher"
+	createCmd = "create"
+	deleteCmd = "delete"
+	moveCmd   = "move"
+)
+
+type Client struct {
+	Session *session.Session
+}
+
+func (c *Client) Create(name string, args ...string) error {
+	args = append([]string{name, createCmd}, args...)
+	err := c.ExecuteCommand(rancher, args...)
+	if err != nil {
+		return err
+	}
+
+	c.Session.RegisterCleanupFunc(func() error {
+		return c.Delete(name, args...)
+	})
+
+	return nil
+}
+
+func (c *Client) Delete(name string, args ...string) error {
+	args = append([]string{name, deleteCmd}, args...)
+
+	return c.ExecuteCommand(rancher, args...)
+}
+
+func (c *Client) Exists(rancher, resourceType, name string) error {
+	cmdStr := fmt.Sprintf("%s %s ls | grep %s", rancher, resourceType, name)
+	cmd := exec.Command("sh", "-c", cmdStr)
+	err := cmd.Run()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if exitError.ExitCode() != 0 {
+				return fmt.Errorf("error validating %s exists: %v", name, err)
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// ExecuteCommand will execute a command and log any errors.
+func (c *Client) ExecuteCommand(name string, args ...string) error {
+	command := exec.Command(name, args...)
+	_, err := command.Output()
+	if err != nil {
+		return fmt.Errorf("error executing command '%s': %v", name, err)
+	}
+
+	return nil
+}
+
+// NewClient will download the CLI and login to the Rancher server.
+func NewClient(session *session.Session, token, host string, client *management.Client) (*Client, error) {
+	c := &Client{
+		Session: session,
+	}
+
+	projectConfig := &management.Project{
+		ClusterID: "local",
+		Name:      namegen.AppendRandomString("project"),
+	}
+
+	testProject, err := client.Project.Create(projectConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Logging into Rancher server...")
+	err = c.ExecuteCommand(rancher, "login", "--token", token, "https://"+host, "--skip-verify", "--context", testProject.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/extensions/cli/cli.go
+++ b/extensions/cli/cli.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	ranchercli "github.com/rancher/shepherd/clients/ranchercli"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	rancher    = "rancher"
+	context    = "context"
+	projects   = "projects"
+	namespaces = "namespaces"
+	catalog    = "catalog"
+)
+
+// SwitchContext will display the current context and switch to the default one.
+func SwitchContext(client *ranchercli.Client) error {
+	logrus.Infof("Listing the current context...")
+	err := client.ExecuteCommand(rancher, context, "current")
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Switching to the default context...")
+	err = client.ExecuteCommand(rancher, context, "switch")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateProjects will create and projects in the specified cluster.
+func CreateProjects(client *ranchercli.Client, projectName, cluster string) error {
+	logrus.Infof("Creating a project...")
+	err := client.ExecuteCommand(rancher, projects, "create", "--cluster", cluster, projectName)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Validating the project exists...")
+	err = client.Exists(rancher, projects, projectName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteProjects will delete projects in the specified cluster.
+func DeleteProjects(client *ranchercli.Client, projectName string) error {
+	logrus.Infof("Deleting the project...")
+	err := client.Delete(projects, projectName)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Validating the project is deleted...")
+	err = client.ExecuteCommand(rancher, projects, "ls", "|", "grep", projectName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateNamespaces will create namespaces in the specified cluster.
+func CreateNamespaces(client *ranchercli.Client, namespaceName, projectName string) error {
+	logrus.Infof("Creating a namespace in default project...")
+	err := client.Create(namespaces, namespaceName)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Validating the namespace exists...")
+	err = client.Exists(rancher, namespaces, namespaceName)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Creating test project...")
+	err = client.Create(projects, "--cluster", "local", projectName)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Validating the project exists...")
+	err = client.Exists(rancher, projects, projectName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteNamespaces will delete namespaces in the specified cluster.
+func DeleteNamespaces(client *ranchercli.Client, namespaceName, projectName string) error {
+	logrus.Infof("Deleting the namespace...")
+	err := client.Delete(namespaces, namespaceName)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Deleting the project...")
+	err = client.Delete(projects, projectName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateCatalogs will create and delete catalogs in the specified cluster.
+func CreateCatalogs(client *ranchercli.Client, catalogName string) error {
+	logrus.Infof("Creating a catalog...")
+	err := client.ExecuteCommand(rancher, catalog, "add", catalogName, "https://git.rancher.io/helm3-charts")
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Validating the catalog exists...")
+	err = client.Exists(rancher, catalog, catalogName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteCatalogs will delete catalogs in the specified cluster.
+func DeleteCatalogs(client *ranchercli.Client, catalogName string) error {
+	logrus.Infof("Deleting the catalog...")
+	err := client.Delete(catalog, catalogName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Backport of https://github.com/rancher/shepherd/pull/145.