### PR TITLE
[2.8] Add Alerting Drivers Chart Installation, Update Monitoring and Logging Charts to Support Different Provider Installations

### DIFF
--- a/extensions/charts/awsoutoftree.go
+++ b/extensions/charts/awsoutoftree.go
@@ -44,7 +44,7 @@ func InstallAWSOutOfTreeChart(client *rancher.Client, installOptions *InstallOpt
 
 	chartInstallAction := awsChartInstallAction(awsChartInstallActionPayload, repoName, kubeSystemNamespace, installOptions.ProjectID, isLeaderMigration)
 
-	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.Cluster.ID)
 	if err != nil {
 		return err
 	}
@@ -223,9 +223,9 @@ func awsChartInstallAction(awsChartInstallActionPayload *payloadOpts, repoName, 
 
 	chartInstall := newChartInstall(
 		awsChartInstallActionPayload.Name,
-		awsChartInstallActionPayload.InstallOptions.Version,
-		awsChartInstallActionPayload.InstallOptions.ClusterID,
-		awsChartInstallActionPayload.InstallOptions.ClusterName,
+		awsChartInstallActionPayload.Version,
+		awsChartInstallActionPayload.Cluster.ID,
+		awsChartInstallActionPayload.Cluster.Name,
 		awsChartInstallActionPayload.Host,
 		repoName,
 		chartProject,

--- a/extensions/charts/charts.go
+++ b/extensions/charts/charts.go
@@ -7,6 +7,7 @@ import (
 	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/kubeapi/workloads/daemonsets"
 	"github.com/rancher/shepherd/extensions/kubeapi/workloads/deployments"
@@ -30,10 +31,9 @@ const (
 
 // InstallOptions is a struct of the required options to install a chart.
 type InstallOptions struct {
-	Version     string
-	ClusterID   string
-	ClusterName string
-	ProjectID   string
+	Cluster   *clusters.ClusterMeta
+	Version   string
+	ProjectID string
 }
 
 // payloadOpts is a private struct that contains the options for the chart payloads.
@@ -59,16 +59,22 @@ type RancherIstioOpts struct {
 
 // RancherMonitoringOpts is a struct of the required options to install Rancher Monitoring with desired chart values.
 type RancherMonitoringOpts struct {
-	IngressNginx         bool
-	RKEControllerManager bool
-	RKEEtcd              bool
-	RKEProxy             bool
-	RKEScheduler         bool
+	IngressNginx      bool `json:"ingressNginx" yaml:"ingressNginx"`
+	ControllerManager bool `json:"controllerManager" yaml:"controllerManager"`
+	Etcd              bool `json:"etcd" yaml:"etcd"`
+	Proxy             bool `json:"proxy" yaml:"proxy"`
+	Scheduler         bool `json:"scheduler" yaml:"scheduler"`
 }
 
 // RancherLoggingOpts is a struct of the required options to install Rancher Logging with desired chart values.
 type RancherLoggingOpts struct {
 	AdditionalLoggingSources bool
+}
+
+// RancherAlertingOpts is a struct of the required options to install Rancher Alerting Drivers with desired chart values.
+type RancherAlertingOpts struct {
+	SMS   bool
+	Teams bool
 }
 
 // GetChartCaseEndpointResult is a struct that GetChartCaseEndpoint helper function returns.

--- a/extensions/charts/rancheralerting.go
+++ b/extensions/charts/rancheralerting.go
@@ -1,0 +1,181 @@
+package charts
+
+import (
+	"context"
+	"fmt"
+
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/clients/rancher/catalog"
+	"github.com/rancher/shepherd/extensions/defaults"
+	kubenamespaces "github.com/rancher/shepherd/extensions/kubeapi/namespaces"
+	"github.com/rancher/shepherd/extensions/namespaces"
+	"github.com/rancher/shepherd/pkg/api/steve/catalog/types"
+	"github.com/rancher/shepherd/pkg/wait"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	// Namespace that rancher alerting drivers chart is installed
+	RancherAlertingNamespace = RancherMonitoringNamespace
+	// Name of the rancher alerting drivers chart
+	RancherAlertingName = "rancher-alerting-drivers"
+)
+
+// InstallRancherALertingChart is a helper function that installs the rancher-alerting-drivers chart.
+func InstallRancherAlertingChart(client *rancher.Client, installOptions *InstallOptions, rancherAlertingOpts *RancherAlertingOpts) error {
+	serverSetting, err := client.Management.Setting.ByID(serverURLSettingID)
+	if err != nil {
+		return err
+	}
+
+	registrySetting, err := client.Management.Setting.ByID(defaultRegistrySettingID)
+	if err != nil {
+		return err
+	}
+
+	alertingChartInstallActionPayload := &payloadOpts{
+		InstallOptions:  *installOptions,
+		Name:            RancherAlertingName,
+		Namespace:       RancherAlertingNamespace,
+		Host:            serverSetting.Value,
+		DefaultRegistry: registrySetting.Value,
+	}
+
+	chartInstallAction := newAlertingChartInstallAction(alertingChartInstallActionPayload, rancherAlertingOpts)
+	if err != nil {
+		return err
+	}
+
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.Cluster.ID)
+	if err != nil {
+		return err
+	}
+
+	// Cleanup registration
+	client.Session.RegisterCleanupFunc(func() error {
+		// UninstallAction for when uninstalling the rancher-alerting-drivers chart
+		defaultChartUninstallAction := newChartUninstallAction()
+
+		err = catalogClient.UninstallChart(RancherAlertingName, RancherAlertingNamespace, defaultChartUninstallAction)
+		if err != nil {
+			return err
+		}
+
+		watchAppInterface, err := catalogClient.Apps(RancherAlertingNamespace).Watch(context.TODO(), metav1.ListOptions{
+			FieldSelector:  "metadata.name=" + RancherAlertingName,
+			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+		})
+		if err != nil {
+			return err
+		}
+
+		err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+			if event.Type == watch.Error {
+				return false, fmt.Errorf("there was an error uninstalling rancher alert drivers chart")
+			} else if event.Type == watch.Deleted {
+				return true, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		monitoringChart, err := GetChartStatus(client, installOptions.Cluster.ID, RancherMonitoringNamespace, RancherMonitoringName)
+		if err != nil {
+			return err
+		}
+
+		// prevent hitting delete twice for the monitoring namespace while CRDs are being deleted
+		if !monitoringChart.IsAlreadyInstalled {
+			steveclient, err := client.Steve.ProxyDownstream(installOptions.Cluster.ID)
+			if err != nil {
+				return err
+			}
+
+			namespaceClient := steveclient.SteveType(namespaces.NamespaceSteveType)
+
+			namespace, err := namespaceClient.ByID(RancherAlertingNamespace)
+			if err != nil {
+				return err
+			}
+
+			err = namespaceClient.Delete(namespace)
+			if err != nil {
+				return err
+			}
+
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+			adminDynamicClient, err := adminClient.GetDownStreamClusterClient(installOptions.Cluster.ID)
+			if err != nil {
+				return err
+			}
+			adminNamespaceResource := adminDynamicClient.Resource(kubenamespaces.NamespaceGroupVersionResource).Namespace("")
+
+			watchNamespaceInterface, err := adminNamespaceResource.Watch(context.TODO(), metav1.ListOptions{
+				FieldSelector:  "metadata.name=" + RancherAlertingNamespace,
+				TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+			})
+			if err != nil {
+				return err
+			}
+
+			err = wait.WatchWait(watchNamespaceInterface, func(event watch.Event) (ready bool, err error) {
+				if event.Type == watch.Deleted {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	err = catalogClient.InstallChart(chartInstallAction, catalog.RancherChartRepo)
+	if err != nil {
+		return err
+	}
+
+	// wait for chart to be full deployed
+	watchAppInterface, err := catalogClient.Apps(RancherAlertingNamespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  "metadata.name=" + RancherAlertingName,
+		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+	})
+	if err != nil {
+		return err
+	}
+
+	return wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
+		app := event.Object.(*catalogv1.App)
+
+		state := app.Status.Summary.State
+		if state == string(catalogv1.StatusDeployed) {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func newAlertingChartInstallAction(p *payloadOpts, opts *RancherAlertingOpts) *types.ChartInstallAction {
+	alertingValues := map[string]interface{}{
+		"prom2teams": map[string]interface{}{
+			"enabled": opts.Teams,
+		},
+		"sachet": map[string]interface{}{
+			"enabled": opts.SMS,
+		},
+	}
+
+	chartInstall := newChartInstall(p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, alertingValues)
+	chartInstalls := []types.ChartInstall{*chartInstall}
+
+	return newChartInstallAction(p.Namespace, p.ProjectID, chartInstalls)
+}

--- a/extensions/charts/ranchergatekeeper.go
+++ b/extensions/charts/ranchergatekeeper.go
@@ -47,7 +47,7 @@ func InstallRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 
 	chartInstallAction := newGatekeeperChartInstallAction(gatekeeperChartInstallActionPayload)
 
-	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.Cluster.ID)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func InstallRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 			return err
 		}
 
-		steveclient, err := client.Steve.ProxyDownstream(installOptions.ClusterID)
+		steveclient, err := client.Steve.ProxyDownstream(installOptions.Cluster.ID)
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ func InstallRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 		if err != nil {
 			return err
 		}
-		adminDynamicClient, err := adminClient.GetDownStreamClusterClient(installOptions.ClusterID)
+		adminDynamicClient, err := adminClient.GetDownStreamClusterClient(installOptions.Cluster.ID)
 		if err != nil {
 			return err
 		}
@@ -146,7 +146,6 @@ func InstallRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 			FieldSelector:  "metadata.name=" + RancherGatekeeperNamespace,
 			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 		})
-
 		if err != nil {
 			return err
 		}
@@ -190,8 +189,8 @@ func InstallRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 
 // newGatekeeperChartInstallAction is a helper function that returns an array of newChartInstallActions for installing the gatekeeper and gatekeepr-crd charts
 func newGatekeeperChartInstallAction(p *payloadOpts) *types.ChartInstallAction {
-	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, nil)
-	chartInstallCRD := newChartInstall(p.Name+"-crd", p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, nil)
+	chartInstall := newChartInstall(p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, nil)
+	chartInstallCRD := newChartInstall(p.Name+"-crd", p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, nil)
 
 	chartInstalls := []types.ChartInstall{*chartInstallCRD, *chartInstall}
 
@@ -222,7 +221,7 @@ func UpgradeRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 
 	chartUpgradeAction := newGatekeeperChartUpgradeAction(gatekeeperChartUpgradeActionPayload)
 
-	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.Cluster.ID)
 	if err != nil {
 		return err
 	}
@@ -236,7 +235,7 @@ func UpgradeRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 	if err != nil {
 		return err
 	}
-	adminCatalogClient, err := adminClient.GetClusterCatalogClient(installOptions.ClusterID)
+	adminCatalogClient, err := adminClient.GetClusterCatalogClient(installOptions.Cluster.ID)
 	if err != nil {
 		return err
 	}
@@ -290,8 +289,8 @@ func UpgradeRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 
 // newGatekeeperChartUpgradeAction is a private helper function that returns chart upgrade action.
 func newGatekeeperChartUpgradeAction(p *payloadOpts) *types.ChartUpgradeAction {
-	chartUpgrade := newChartUpgrade(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, nil)
-	chartUpgradeCRD := newChartUpgrade(p.Name+"-crd", p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, nil)
+	chartUpgrade := newChartUpgrade(p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
+	chartUpgradeCRD := newChartUpgrade(p.Name+"-crd", p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
 	chartUpgrades := []types.ChartUpgrade{*chartUpgradeCRD, *chartUpgrade}
 
 	chartUpgradeAction := newChartUpgradeAction(p.Namespace, chartUpgrades)

--- a/extensions/charts/rancheristio.go
+++ b/extensions/charts/rancheristio.go
@@ -45,7 +45,7 @@ func InstallRancherIstioChart(client *rancher.Client, installOptions *InstallOpt
 
 	chartInstallAction := newIstioChartInstallAction(istioChartInstallActionPayload, rancherIstioOpts)
 
-	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.Cluster.ID)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func InstallRancherIstioChart(client *rancher.Client, installOptions *InstallOpt
 			return err
 		}
 
-		steveclient, err := client.Steve.ProxyDownstream(installOptions.ClusterID)
+		steveclient, err := client.Steve.ProxyDownstream(installOptions.Cluster.ID)
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func InstallRancherIstioChart(client *rancher.Client, installOptions *InstallOpt
 		if err != nil {
 			return err
 		}
-		adminDynamicClient, err := adminClient.GetDownStreamClusterClient(installOptions.ClusterID)
+		adminDynamicClient, err := adminClient.GetDownStreamClusterClient(installOptions.Cluster.ID)
 		if err != nil {
 			return err
 		}
@@ -111,7 +111,6 @@ func InstallRancherIstioChart(client *rancher.Client, installOptions *InstallOpt
 			FieldSelector:  "metadata.name=" + RancherIstioNamespace,
 			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 		})
-
 		if err != nil {
 			return err
 		}
@@ -178,10 +177,10 @@ func newIstioChartInstallAction(p *payloadOpts, rancherIstioOpts *RancherIstioOp
 			"enabled": rancherIstioOpts.CNI,
 		},
 	}
-	chartInstall := newChartInstall(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, istioValues)
+	chartInstall := newChartInstall(p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, rancherChartsName, p.ProjectID, p.DefaultRegistry, istioValues)
 	chartInstalls := []types.ChartInstall{*chartInstall}
 
-	chartInstallAction := newChartInstallAction(p.Namespace, p.InstallOptions.ProjectID, chartInstalls)
+	chartInstallAction := newChartInstallAction(p.Namespace, p.ProjectID, chartInstalls)
 
 	return chartInstallAction
 }
@@ -208,7 +207,7 @@ func UpgradeRancherIstioChart(client *rancher.Client, installOptions *InstallOpt
 
 	chartUpgradeAction := newIstioChartUpgradeAction(istioChartUpgradeActionPayload, rancherIstioOpts)
 
-	catalogClient, err := client.GetClusterCatalogClient(installOptions.ClusterID)
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.Cluster.ID)
 	if err != nil {
 		return err
 	}
@@ -222,7 +221,7 @@ func UpgradeRancherIstioChart(client *rancher.Client, installOptions *InstallOpt
 	if err != nil {
 		return err
 	}
-	adminCatalogClient, err := adminClient.GetClusterCatalogClient(installOptions.ClusterID)
+	adminCatalogClient, err := adminClient.GetClusterCatalogClient(installOptions.Cluster.ID)
 	if err != nil {
 		return err
 	}
@@ -299,7 +298,7 @@ func newIstioChartUpgradeAction(p *payloadOpts, rancherIstioOpts *RancherIstioOp
 			"enabled": rancherIstioOpts.CNI,
 		},
 	}
-	chartUpgrade := newChartUpgrade(p.Name, p.InstallOptions.Version, p.InstallOptions.ClusterID, p.InstallOptions.ClusterName, p.Host, p.DefaultRegistry, istioValues)
+	chartUpgrade := newChartUpgrade(p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, istioValues)
 	chartUpgrades := []types.ChartUpgrade{*chartUpgrade}
 
 	chartUpgradeAction := newChartUpgradeAction(p.Namespace, chartUpgrades)


### PR DESCRIPTION
## Issue(s): https://github.com/rancher/qa-tasks/issues/1195 & https://github.com/rancher/qa-tasks/issues/1199 & https://github.com/rancher/qa-tasks/issues/1194
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Chart installations only support RKE1 clusters. Ultimately for chart installations on the Airgap environment, the chart tests need to be enhanced to include an Alerting Driver chart too.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
Add Monitoring and Logging charts' payload mappers. Update chart installs option struct to have cluster meta - which is used within these mappers. Add Alerting Driver installation function that supports RKE1/RKE2/K3s installations.
