### PR TITLE
[v2.7] Add docker install support for RKE1 custom cluster

### DIFF
--- a/extensions/clusters/clusterconfig.go
+++ b/extensions/clusters/clusterconfig.go
@@ -7,30 +7,31 @@ import (
 )
 
 type ClusterConfig struct {
-	KubernetesVersion    string                                   `json:"kubernetesVersion" yaml:"kubernetesVersion"`
-	CNI                  string                                   `json:"cni" yaml:"cni"`
-	PSACT                string                                   `json:"psact" yaml:"psact"`
-	PNI                  bool                                     `json:"pni" yaml:"pni"`
-	NodePools            []provisioningInput.NodePools            `json:"nodepools" yaml:"nodepools"`
-	MachinePools         []provisioningInput.MachinePools         `json:"machinepools" yaml:"machinepools"`
-	CloudProvider        string                                   `json:"cloudProvider" yaml:"cloudProvider"`
-	Providers            *[]string                                `json:"providers" yaml:"providers"`
-	NodeProviders        *[]string                                `json:"nodeProviders" yaml:"nodeProviders"`
-	Hardened             bool                                     `json:"hardened" yaml:"hardened"`
-	AddOnConfig          *provisioningInput.AddOnConfig           `json:"addonConfig" yaml:"addonConfig"`
-	AgentEnvVars         *[]rkev1.EnvVar                          `json:"agentEnvVars" yaml:"agentEnvVars"`
-	AgentEnvVarsRKE1     *[]management.EnvVar                     `json:"agentEnvVarsRKE1" yaml:"agentEnvVarsRKE1"`
-	ClusterAgent         *management.AgentDeploymentCustomization `json:"clusterAgent" yaml:"clusterAgent"`
-	FleetAgent           *management.AgentDeploymentCustomization `json:"fleetAgent" yaml:"fleetAgent"`
-	ETCD                 *rkev1.ETCD                              `json:"etcd" yaml:"etcd"`
-	ETCDRKE1             *management.ETCDService                  `json:"etcdRKE1" yaml:"etcdRKE1"`
-	LabelsAndAnnotations *provisioningInput.LabelsAndAnnotations  `json:"labelsAndAnnotations" yaml:"labelsAndAnnotations"`
-	Networking           *provisioningInput.Networking            `json:"networking" yaml:"networking"`
-	Registries           *provisioningInput.Registries            `json:"registries" yaml:"registries"`
-	UpgradeStrategy      *rkev1.ClusterUpgradeStrategy            `json:"upgradeStrategy" yaml:"upgradeStrategy"`
-	Advanced             *provisioningInput.Advanced              `json:"advanced" yaml:"advanced"`
-	ClusterSSHTests      []provisioningInput.SSHTestCase          `json:"clusterSSHTests" yaml:"clusterSSHTests"`
-	CRIDockerd           bool                                     `json:"criDockerd" yaml:"criDockerd"`
+	KubernetesVersion              string                                            `json:"kubernetesVersion" yaml:"kubernetesVersion"`
+	CNI                            string                                            `json:"cni" yaml:"cni"`
+	PSACT                          string                                            `json:"psact" yaml:"psact"`
+	PNI                            bool                                              `json:"pni" yaml:"pni"`
+	NodePools                      []provisioningInput.NodePools                     `json:"nodepools" yaml:"nodepools"`
+	MachinePools                   []provisioningInput.MachinePools                  `json:"machinepools" yaml:"machinepools"`
+	CloudProvider                  string                                            `json:"cloudProvider" yaml:"cloudProvider"`
+	Providers                      *[]string                                         `json:"providers" yaml:"providers"`
+	NodeProviders                  *[]string                                         `json:"nodeProviders" yaml:"nodeProviders"`
+	Hardened                       bool                                              `json:"hardened" yaml:"hardened"`
+	AddOnConfig                    *provisioningInput.AddOnConfig                    `json:"addonConfig" yaml:"addonConfig"`
+	AgentEnvVars                   *[]rkev1.EnvVar                                   `json:"agentEnvVars" yaml:"agentEnvVars"`
+	AgentEnvVarsRKE1               *[]management.EnvVar                              `json:"agentEnvVarsRKE1" yaml:"agentEnvVarsRKE1"`
+	ClusterAgent                   *management.AgentDeploymentCustomization          `json:"clusterAgent" yaml:"clusterAgent"`
+	FleetAgent                     *management.AgentDeploymentCustomization          `json:"fleetAgent" yaml:"fleetAgent"`
+	ETCD                           *rkev1.ETCD                                       `json:"etcd" yaml:"etcd"`
+	ETCDRKE1                       *management.ETCDService                           `json:"etcdRKE1" yaml:"etcdRKE1"`
+	LabelsAndAnnotations           *provisioningInput.LabelsAndAnnotations           `json:"labelsAndAnnotations" yaml:"labelsAndAnnotations"`
+	Networking                     *provisioningInput.Networking                     `json:"networking" yaml:"networking"`
+	Registries                     *provisioningInput.Registries                     `json:"registries" yaml:"registries"`
+	UpgradeStrategy                *rkev1.ClusterUpgradeStrategy                     `json:"upgradeStrategy" yaml:"upgradeStrategy"`
+	Advanced                       *provisioningInput.Advanced                       `json:"advanced" yaml:"advanced"`
+	ClusterSSHTests                []provisioningInput.SSHTestCase                   `json:"clusterSSHTests" yaml:"clusterSSHTests"`
+	CRIDockerd                     bool                                              `json:"criDockerd" yaml:"criDockerd"`
+	RKE1CustomClusterDockerInstall *provisioningInput.RKE1CustomClusterDockerInstall `json:"rke1CustomClusterDockerInstall" yaml:"rke1CustomClusterDockerInstall"`
 }
 
 // ConvertConfigToClusterConfig converts the config from (user) provisioning input to a cluster config
@@ -57,6 +58,7 @@ func ConvertConfigToClusterConfig(provisioningConfig *provisioningInput.Config) 
 	newConfig.PSACT = provisioningConfig.PSACT
 	newConfig.PNI = provisioningConfig.PNI
 	newConfig.ClusterSSHTests = provisioningConfig.ClusterSSHTests
+	newConfig.RKE1CustomClusterDockerInstall = provisioningConfig.RKE1CustomClusterDockerInstall
 
 	return &newConfig
 }

--- a/extensions/provisioning/creates.go
+++ b/extensions/provisioning/creates.go
@@ -507,6 +507,23 @@ func CreateProvisioningRKE1CustomCluster(client *rancher.Client, externalNodePro
 			command = createRKE1RegistrationCommand(command, node.PublicIPAddress, node.PrivateIPAddress, clustersConfig.NodePools[poolIndex])
 			logrus.Infof("Command: %s", command)
 
+			if clustersConfig.RKE1CustomClusterDockerInstall != nil && clustersConfig.RKE1CustomClusterDockerInstall.InstallDockerURL != "" {
+				_, err := node.ExecuteCommand("curl " + clustersConfig.RKE1CustomClusterDockerInstall.InstallDockerURL + " | sh")
+				if err != nil {
+					return nil, nil, err
+				}
+
+				_, err = node.ExecuteCommand("sudo systemctl start docker")
+				if err != nil {
+					return nil, nil, err
+				}
+
+				_, err = node.ExecuteCommand("sudo chmod 777 /var/run/docker.sock")
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+
 			output, err := node.ExecuteCommand(command)
 			if err != nil {
 				return nil, nil, err

--- a/extensions/provisioninginput/config.go
+++ b/extensions/provisioninginput/config.go
@@ -196,33 +196,38 @@ type NodePools struct {
 	NodeRoles nodepools.NodeRoles `json:"nodeRoles,omitempty" yaml:"nodeRoles,omitempty" default:"[]"`
 }
 
+type RKE1CustomClusterDockerInstall struct {
+	InstallDockerURL string `json:"installDockerURL" yaml:"installDockerURL"`
+}
+
 type Config struct {
-	NodePools              []NodePools                              `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
-	MachinePools           []MachinePools                           `json:"machinePools,omitempty" yaml:"machinePools,omitempty"`
-	CloudProvider          string                                   `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
-	Providers              []string                                 `json:"providers,omitempty" yaml:"providers,omitempty"`
-	NodeProviders          []string                                 `json:"nodeProviders,omitempty" yaml:"nodeProviders,omitempty"`
-	Hardened               bool                                     `json:"hardened,omitempty" yaml:"hardened,omitempty"`
-	AddOnConfig            *AddOnConfig                             `json:"addonConfig,omitempty" yaml:"addonConfig,omitempty"`
-	K3SKubernetesVersions  []string                                 `json:"k3sKubernetesVersion,omitempty" yaml:"k3sKubernetesVersion,omitempty"`
-	RKE1KubernetesVersions []string                                 `json:"rke1KubernetesVersion,omitempty" yaml:"rke1KubernetesVersion,omitempty"`
-	RKE2KubernetesVersions []string                                 `json:"rke2KubernetesVersion,omitempty" yaml:"rke2KubernetesVersion,omitempty"`
-	CNIs                   []string                                 `json:"cni,omitempty" yaml:"cni,omitempty"`
-	PSACT                  string                                   `json:"psact,omitempty" yaml:"psact,omitempty"`
-	PNI                    bool                                     `json:"pni,omitempty" yaml:"pni,omitempty"`
-	AgentEnvVars           *[]rkev1.EnvVar                          `json:"agentEnvVars,omitempty" yaml:"agentEnvVars,omitempty"`
-	AgentEnvVarsRKE1       *[]management.EnvVar                     `json:"agentEnvVarsRKE1,omitempty" yaml:"agentEnvVarsRKE1,omitempty"`
-	ClusterAgent           *management.AgentDeploymentCustomization `json:"clusterAgent,omitempty" yaml:"clusterAgent,omitempty"`
-	FleetAgent             *management.AgentDeploymentCustomization `json:"fleetAgent,omitempty" yaml:"fleetAgent,omitempty"`
-	ETCD                   *rkev1.ETCD                              `json:"etcd,omitempty" yaml:"etcd,omitempty"`
-	ETCDRKE1               *management.ETCDService                  `json:"etcdRKE1,omitempty" yaml:"etcdRKE1,omitempty"`
-	LabelsAndAnnotations   *LabelsAndAnnotations                    `json:"labelsAndAnnotations,omitempty" yaml:"labelsAndAnnotations,omitempty"`
-	Networking             *Networking                              `json:"networking,omitempty" yaml:"networking,omitempty"`
-	Registries             *Registries                              `json:"registries,omitempty" yaml:"registries,omitempty"`
-	UpgradeStrategy        *rkev1.ClusterUpgradeStrategy            `json:"upgradeStrategy,omitempty" yaml:"upgradeStrategy,omitempty"`
-	Advanced               *Advanced                                `json:"advanced,omitempty" yaml:"advanced,omitempty"`
-	ClusterSSHTests        []SSHTestCase                            `json:"clusterSSHTests,omitempty" yaml:"clusterSSHTests,omitempty"`
-	CRIDockerd             bool                                     `json:"criDockerd,omitempty" yaml:"criDockerd,omitempty"`
+	NodePools                      []NodePools                              `json:"nodePools,omitempty" yaml:"nodePools,omitempty"`
+	MachinePools                   []MachinePools                           `json:"machinePools,omitempty" yaml:"machinePools,omitempty"`
+	CloudProvider                  string                                   `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
+	Providers                      []string                                 `json:"providers,omitempty" yaml:"providers,omitempty"`
+	NodeProviders                  []string                                 `json:"nodeProviders,omitempty" yaml:"nodeProviders,omitempty"`
+	Hardened                       bool                                     `json:"hardened,omitempty" yaml:"hardened,omitempty"`
+	AddOnConfig                    *AddOnConfig                             `json:"addonConfig,omitempty" yaml:"addonConfig,omitempty"`
+	K3SKubernetesVersions          []string                                 `json:"k3sKubernetesVersion,omitempty" yaml:"k3sKubernetesVersion,omitempty"`
+	RKE1KubernetesVersions         []string                                 `json:"rke1KubernetesVersion,omitempty" yaml:"rke1KubernetesVersion,omitempty"`
+	RKE2KubernetesVersions         []string                                 `json:"rke2KubernetesVersion,omitempty" yaml:"rke2KubernetesVersion,omitempty"`
+	CNIs                           []string                                 `json:"cni,omitempty" yaml:"cni,omitempty"`
+	PSACT                          string                                   `json:"psact,omitempty" yaml:"psact,omitempty"`
+	PNI                            bool                                     `json:"pni,omitempty" yaml:"pni,omitempty"`
+	AgentEnvVars                   *[]rkev1.EnvVar                          `json:"agentEnvVars,omitempty" yaml:"agentEnvVars,omitempty"`
+	AgentEnvVarsRKE1               *[]management.EnvVar                     `json:"agentEnvVarsRKE1,omitempty" yaml:"agentEnvVarsRKE1,omitempty"`
+	ClusterAgent                   *management.AgentDeploymentCustomization `json:"clusterAgent,omitempty" yaml:"clusterAgent,omitempty"`
+	FleetAgent                     *management.AgentDeploymentCustomization `json:"fleetAgent,omitempty" yaml:"fleetAgent,omitempty"`
+	ETCD                           *rkev1.ETCD                              `json:"etcd,omitempty" yaml:"etcd,omitempty"`
+	ETCDRKE1                       *management.ETCDService                  `json:"etcdRKE1,omitempty" yaml:"etcdRKE1,omitempty"`
+	LabelsAndAnnotations           *LabelsAndAnnotations                    `json:"labelsAndAnnotations,omitempty" yaml:"labelsAndAnnotations,omitempty"`
+	Networking                     *Networking                              `json:"networking,omitempty" yaml:"networking,omitempty"`
+	Registries                     *Registries                              `json:"registries,omitempty" yaml:"registries,omitempty"`
+	UpgradeStrategy                *rkev1.ClusterUpgradeStrategy            `json:"upgradeStrategy,omitempty" yaml:"upgradeStrategy,omitempty"`
+	Advanced                       *Advanced                                `json:"advanced,omitempty" yaml:"advanced,omitempty"`
+	ClusterSSHTests                []SSHTestCase                            `json:"clusterSSHTests,omitempty" yaml:"clusterSSHTests,omitempty"`
+	CRIDockerd                     bool                                     `json:"criDockerd,omitempty" yaml:"criDockerd,omitempty"`
+	RKE1CustomClusterDockerInstall *RKE1CustomClusterDockerInstall          `json:"rke1CustomClusterDockerInstall,omitempty" yaml:"rke1CustomClusterDockerInstall,omitempty"`
 }
 
 type TemplateConfig struct {


### PR DESCRIPTION
With this PR we can pass docker version in `cattle-config` which can be used for installing docker on RKE1 custom cluster nodes.

In order to pass docker version, provide below field in the config:

```
rke1CustomClusterDockerInstall:
  installDockerURL: "https://releases.rancher.com/install-docker/<version-number>.sh"
```

This change is for the AMIs that doesn't have docker pre-installed and are used in docker and OS checks.