### PR TITLE
[2.9] add updated fields to azure machinepool + nodetemplate

### DIFF
--- a/extensions/machinepools/azure_machine_config.go
+++ b/extensions/machinepools/azure_machine_config.go
@@ -24,6 +24,7 @@ type AzureMachineConfig struct {
 	DiskSize          string   `json:"diskSize" yaml:"diskSize"`
 	DNS               string   `json:"dns,omitempty" yaml:"dns,omitempty"`
 	FaultDomainCount  string   `json:"faultDomainCount" yaml:"faultDomainCount"`
+	Location          string   `json:"location" yaml:"location"`
 	Image             string   `json:"image" yaml:"image"`
 	ManagedDisks      bool     `json:"managedDisks" yaml:"managedDisks"`
 	NoPublicIP        bool     `json:"noPublicIp" yaml:"noPublicIp"`
@@ -59,6 +60,7 @@ func NewAzureMachineConfig(generatedPoolName, namespace string) []unstructured.U
 		machineConfig.Object["availabilitySet"] = azureMachineConfig.AvailabilitySet
 		machineConfig.Object["diskSize"] = azureMachineConfig.DiskSize
 		machineConfig.Object["dns"] = azureMachineConfig.DNS
+		machineConfig.Object["location"] = azureMachineConfig.Location
 		machineConfig.Object["environment"] = azureMachineConfigs.Environment
 		machineConfig.Object["faultDomainCount"] = azureMachineConfig.FaultDomainCount
 		machineConfig.Object["image"] = azureMachineConfig.Image

--- a/extensions/rke1/nodetemplates/azure_config.go
+++ b/extensions/rke1/nodetemplates/azure_config.go
@@ -19,6 +19,7 @@ type AzureNodeTemplateConfig struct {
 	ManagedDisks      bool     `json:"managedDisks" yaml:"managedDisks"`
 	NoPublicIP        bool     `json:"noPublicIp" yaml:"noPublicIp"`
 	OpenPort          []string `json:"openPort" yaml:"openPort"`
+	NSG               string   `json:"nsg" yaml:"nsg"`
 	Plan              string   `json:"plan" yaml:"plan"`
 	PrivateIPAddress  string   `json:"privateIpAddress" yaml:"privateIpAddress"`
 	ResourceGroup     string   `json:"resourceGroup" yaml:"resourceGroup"`


### PR DESCRIPTION
azure was missing fields for location (machinepools) and NSG (nodetemplates) - adding this to the config