### PR TITLE
[v2.9] Fix delete init node for RKE2 clusters

### DIFF
--- a/extensions/clusters/clusters.go
+++ b/extensions/clusters/clusters.go
@@ -1252,7 +1252,7 @@ func logClusterInfoWithChanges(clusterID, clusterInfo string, summary summary.Su
 // WatchAndWaitForCluster is function that waits for a cluster to go unactive before checking its active state.
 func WatchAndWaitForCluster(client *rancher.Client, steveID string) error {
 	var clusterResp *v1.SteveAPIObject
-	err := kwait.PollUntilContextTimeout(context.TODO(), 1*time.Second, defaults.TwoMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
+	err := kwait.PollUntilContextTimeout(context.TODO(), 1*time.Second, defaults.TenMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
 		clusterResp, err = client.Steve.SteveType(ProvisioningSteveResourceType).ByID(steveID)
 		if err != nil {
 			return false, err

--- a/extensions/machinepools/machinepools.go
+++ b/extensions/machinepools/machinepools.go
@@ -28,6 +28,7 @@ const (
 	machineNameSteveLabel    = "rke.cattle.io/machine-name"
 	machinePlanSecretType    = "rke.cattle.io/machine-plan"
 	machineSteveResourceType = "cluster.x-k8s.io.machine"
+	clusterNameLabelKey      = "cluster.x-k8s.io/cluster-name"
 	pool                     = "pool"
 	True                     = "true"
 
@@ -303,8 +304,11 @@ func MatchRoleToPool(poolRole string, allRoles []Roles) int {
 // object for rke2/k3s clusters
 func GetInitMachine(client *rancher.Client, clusterID string) (*v1.SteveAPIObject, error) {
 	logrus.Info("Retrieving secret and identifying machine...")
+
+	clusterID = strings.Replace(clusterID, "fleet-default/", "", 1)
+
 	secret, err := secrets.ListSecrets(client, local, fleetNamespace, metav1.ListOptions{
-		LabelSelector: initNodeLabelKey + "=" + True,
+		LabelSelector: initNodeLabelKey + "=" + True + "," + clusterNameLabelKey + "=" + clusterID,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### PR Description
The delete init node test is working only for K3s clusters and not RKE2 clusters. This is because there is no current way in which the appropriate secret is getting grabbed.

To address this, we need to use a FieldSelector to grab the appropriate downstream cluster.