### PR TITLE
[v2.9] Fix internal IP annotation for custom cluster deletion

### DIFF
--- a/extensions/provisioning/creates.go
+++ b/extensions/provisioning/creates.go
@@ -872,7 +872,9 @@ func DeleteRKE2K3SCustomClusterNodes(client *rancher.Client, clusterID string, c
 
 	for _, nodeToDelete := range nodesToDelete {
 		for _, node := range nodesSteveObjList.Data {
-			if node.Annotations[internalIP] == nodeToDelete.PrivateIPAddress {
+			snippedIP := strings.Split(node.Annotations[internalIP], ",")[0]
+
+			if snippedIP == nodeToDelete.PrivateIPAddress {
 				machine, err := client.Steve.SteveType(machineSteveResourceType).ByID(namespace + "/" + node.Annotations[machineNameAnnotation])
 				if err != nil {
 					return err


### PR DESCRIPTION
### PR Description
In the last iteration of release testing, automation for scaling custom clusters was failing. Upon further investigation, the annotation used appends the hexadecimal number to the private IP address.

That needs to be removed in order for it to consistently work, this PR snips that part of the IP address.