### PR TITLE
[v2.8] Fix RKE1 nodetemplates to include cloud credentials

### DIFF
--- a/extensions/rke1/nodetemplates/aws/create.go
+++ b/extensions/rke1/nodetemplates/aws/create.go
@@ -3,6 +3,7 @@ package nodetemplates
 import (
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/cloudcredentials/aws"
 	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
 	"github.com/rancher/shepherd/pkg/config"
 )
@@ -15,13 +16,21 @@ func CreateAWSNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.NodeTe
 	var amazonEC2NodeTemplateConfig nodetemplates.AmazonEC2NodeTemplateConfig
 	config.LoadConfig(nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey, &amazonEC2NodeTemplateConfig)
 
+	cloudCredential, err := aws.CreateAWSCloudCredentials(rancherClient)
+	if err != nil {
+		return nil, err
+	}
+
 	nodeTemplate := nodetemplates.NodeTemplate{
 		EngineInstallURL:            "https://releases.rancher.com/install-docker/24.0.sh",
 		Name:                        awsEC2NodeTemplateNameBase,
 		AmazonEC2NodeTemplateConfig: &amazonEC2NodeTemplateConfig,
 	}
 
-	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{
+		CloudCredentialID: cloudCredential.ID,
+	}
+
 	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
 
 	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.AmazonEC2NodeTemplateConfigurationFileKey)

--- a/extensions/rke1/nodetemplates/aws_config.go
+++ b/extensions/rke1/nodetemplates/aws_config.go
@@ -5,7 +5,6 @@ const AmazonEC2NodeTemplateConfigurationFileKey = "amazonec2Config"
 
 // AmazonNodeTemplateConfig is configuration need to create a Amazon node template
 type AmazonEC2NodeTemplateConfig struct {
-	AccessKey               string   `json:"accessKey" yaml:"accessKey"`
 	AMI                     string   `json:"ami" yaml:"ami"`
 	BlockDurationMinutes    string   `json:"blockDurationMinutes" yaml:"blockDurationMinutes"`
 	DeviceName              string   `json:"deviceName" yaml:"deviceName"`
@@ -24,7 +23,6 @@ type AmazonEC2NodeTemplateConfig struct {
 	RequestSpotInstance     bool     `json:"requestSpotInstance" yaml:"requestSpotInstance"`
 	Retries                 string   `json:"retries" yaml:"retries"`
 	RootSize                string   `json:"rootSize" yaml:"rootSize"`
-	SecretKey               string   `json:"secretKey" yaml:"secretKey"`
 	SecurityGroup           []string `json:"securityGroup" yaml:"securityGroup"`
 	SecurityGroupReadonly   bool     `json:"securityGroupReadonly" yaml:"securityGroupReadonly"`
 	SessionToken            string   `json:"sessionToken" yaml:"sessionToken"`

--- a/extensions/rke1/nodetemplates/azure_config.go
+++ b/extensions/rke1/nodetemplates/azure_config.go
@@ -6,8 +6,6 @@ const AzureNodeTemplateConfigurationFileKey = "azureConfig"
 // AzureNodeTemplateConfig is configuration need to create a Azure node template
 type AzureNodeTemplateConfig struct {
 	AvailabilitySet   string   `json:"availabilitySet" yaml:"availabilitySet"`
-	ClientID          string   `json:"clientId" yaml:"clientId"`
-	ClientSecret      string   `json:"clientSecret" yaml:"clientSecret"`
 	CustomData        string   `json:"customData" yaml:"customData"`
 	DiskSize          string   `json:"diskSize" yaml:"diskSize"`
 	DNS               string   `json:"dns" yaml:"dns"`
@@ -29,8 +27,6 @@ type AzureNodeTemplateConfig struct {
 	StorageType       string   `json:"storageType" yaml:"storageType"`
 	Subnet            string   `json:"subnet" yaml:"subnet"`
 	SubnetPrefix      string   `json:"subnetPrefix" yaml:"subnetPrefix"`
-	SubscriptionID    string   `json:"subscriptionId" yaml:"subscriptionId"`
-	TenantID          string   `json:"tenantId" yaml:"tenantId"`
 	Type              string   `json:"type" yaml:"type"`
 	UpdateDomainCount string   `json:"updateDomainCount" yaml:"updateDomainCount"`
 	UsePrivateIP      bool     `json:"usePrivateIp" yaml:"usePrivateIp"`

--- a/extensions/rke1/nodetemplates/harvester/create.go
+++ b/extensions/rke1/nodetemplates/harvester/create.go
@@ -3,6 +3,7 @@ package nodetemplates
 import (
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/cloudcredentials/harvester"
 	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
 	"github.com/rancher/shepherd/pkg/config"
 )
@@ -15,13 +16,21 @@ func CreateHarvesterNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.
 	var harvesterNodeTemplateConfig nodetemplates.HarvesterNodeTemplateConfig
 	config.LoadConfig(nodetemplates.HarvesterNodeTemplateConfigurationFileKey, &harvesterNodeTemplateConfig)
 
+	cloudCredential, err := harvester.CreateHarvesterCloudCredentials(rancherClient)
+	if err != nil {
+		return nil, err
+	}
+
 	nodeTemplate := nodetemplates.NodeTemplate{
 		EngineInstallURL:            "https://releases.rancher.com/install-docker/24.0.sh",
 		Name:                        harvesterNodeTemplateNameBase,
 		HarvesterNodeTemplateConfig: &harvesterNodeTemplateConfig,
 	}
 
-	nodeTemplateConfig := &nodetemplates.NodeTemplate{}
+	nodeTemplateConfig := &nodetemplates.NodeTemplate{
+		CloudCredentialID: cloudCredential.ID,
+	}
+
 	config.LoadConfig(nodetemplates.NodeTemplateConfigurationFileKey, nodeTemplateConfig)
 
 	nodeTemplateFinal, err := nodeTemplate.MergeOverride(nodeTemplateConfig, nodetemplates.HarvesterNodeTemplateConfigurationFileKey)

--- a/extensions/rke1/nodetemplates/harvester_config.go
+++ b/extensions/rke1/nodetemplates/harvester_config.go
@@ -6,14 +6,11 @@ const HarvesterNodeTemplateConfigurationFileKey = "harvesterConfig"
 // HarvesterNodeTemplateConfig is configuration need to create a Harvester node template
 type HarvesterNodeTemplateConfig struct {
 	CloudConfig       string `json:"cloudConfig" yaml:"cloudConfig"`
-	ClusterID         string `json:"clusterId" yaml:"clusterId"`
-	ClusterType       string `json:"clusterType" yaml:"clusterType"`
 	CPUCount          string `json:"cpuCount" yaml:"cpuCount"`
 	DiskBus           string `json:"diskBus" yaml:"diskBus"`
 	DiskSize          string `json:"diskSize" yaml:"diskSize"`
 	ImageName         string `json:"imageName" yaml:"imageName"`
 	KeyPairName       string `json:"keyPairName" yaml:"keyPairName"`
-	KubeconfigContent string `json:"kubeconfigContent" yaml:"kubeconfigContent"`
 	MemorySize        string `json:"memorySize" yaml:"memorySize"`
 	NetworkData       string `json:"networkData" yaml:"networkData"`
 	NetworkModel      string `json:"networkModel" yaml:"networkModel"`

--- a/extensions/rke1/nodetemplates/linode_config.go
+++ b/extensions/rke1/nodetemplates/linode_config.go
@@ -19,7 +19,6 @@ type LinodeNodeTemplateConfig struct {
 	StackscriptData string `json:"stackscriptData" yaml:"stackscriptData"`
 	SwapSize        string `json:"swapSize" yaml:"swapSize"`
 	Tags            string `json:"tags" yaml:"tags"`
-	Token           string `json:"token" yaml:"token"`
 	Type            string `json:"type" yaml:"type"`
 	UAPrefix        string `json:"uaPrefix" yaml:"uaPrefix"`
 }


### PR DESCRIPTION
Backport of https://github.com/rancher/shepherd/pull/194.