### PR TITLE
[v2.7] Modify hosted provider create methods to not read directly from config file

### DIFF
--- a/extensions/clusters/aks/aks_cluster_config.go
+++ b/extensions/clusters/aks/aks_cluster_config.go
@@ -2,7 +2,6 @@ package aks
 
 import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/pkg/config"
 )
 
 const (
@@ -78,10 +77,7 @@ func aksNodePoolConstructor(aksNodePoolConfigs *[]NodePool, kubernetesVersion st
 	return aksNodePools
 }
 
-func HostClusterConfig(displayName, cloudCredentialID string) *management.AKSClusterConfigSpec {
-	var aksClusterConfig ClusterConfig
-	config.LoadConfig(AKSClusterConfigConfigurationFileKey, &aksClusterConfig)
-
+func HostClusterConfig(displayName, cloudCredentialID string, aksClusterConfig ClusterConfig) *management.AKSClusterConfigSpec {
 	return &management.AKSClusterConfigSpec{
 		AzureCredentialSecret: cloudCredentialID,
 		ClusterName:           displayName,

--- a/extensions/clusters/aks/create.go
+++ b/extensions/clusters/aks/create.go
@@ -6,8 +6,8 @@ import (
 )
 
 // CreateAKSHostedCluster is a helper function that creates an AKS hosted cluster.
-func CreateAKSHostedCluster(client *rancher.Client, displayName, cloudCredentialID string, enableClusterAlerting, enableClusterMonitoring, enableNetworkPolicy, windowsPreferedCluster bool, labels map[string]string) (*management.Cluster, error) {
-	aksHostCluster := HostClusterConfig(displayName, cloudCredentialID)
+func CreateAKSHostedCluster(client *rancher.Client, displayName, cloudCredentialID string, aksClusterConfig ClusterConfig, enableClusterAlerting, enableClusterMonitoring, enableNetworkPolicy, windowsPreferedCluster bool, labels map[string]string) (*management.Cluster, error) {
+	aksHostCluster := HostClusterConfig(displayName, cloudCredentialID, aksClusterConfig)
 	cluster := &management.Cluster{
 		AKSConfig:               aksHostCluster,
 		DockerRootDir:           "/var/lib/docker",

--- a/extensions/clusters/eks/create.go
+++ b/extensions/clusters/eks/create.go
@@ -6,8 +6,8 @@ import (
 )
 
 // CreateEKSHostedCluster is a helper function that creates an EKS hosted cluster
-func CreateEKSHostedCluster(client *rancher.Client, displayName, cloudCredentialID string, enableClusterAlerting, enableClusterMonitoring, enableNetworkPolicy, windowsPreferedCluster bool, labels map[string]string) (*management.Cluster, error) {
-	eksHostCluster := eksHostClusterConfig(displayName, cloudCredentialID)
+func CreateEKSHostedCluster(client *rancher.Client, displayName, cloudCredentialID string, eksClusterConfig ClusterConfig, enableClusterAlerting, enableClusterMonitoring, enableNetworkPolicy, windowsPreferedCluster bool, labels map[string]string) (*management.Cluster, error) {
+	eksHostCluster := eksHostClusterConfig(displayName, cloudCredentialID, eksClusterConfig)
 	cluster := &management.Cluster{
 		DockerRootDir:           "/var/lib/docker",
 		EKSConfig:               eksHostCluster,

--- a/extensions/clusters/eks/eks_cluster_config.go
+++ b/extensions/clusters/eks/eks_cluster_config.go
@@ -2,7 +2,6 @@ package eks
 
 import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/pkg/config"
 )
 
 const (
@@ -91,10 +90,7 @@ func nodeGroupsConstructor(nodeGroupsConfig *[]NodeGroupConfig, kubernetesVersio
 	return nodeGroups
 }
 
-func eksHostClusterConfig(displayName, cloudCredentialID string) *management.EKSClusterConfigSpec {
-	var eksClusterConfig ClusterConfig
-	config.LoadConfig(EKSClusterConfigConfigurationFileKey, &eksClusterConfig)
-
+func eksHostClusterConfig(displayName, cloudCredentialID string, eksClusterConfig ClusterConfig) *management.EKSClusterConfigSpec {
 	return &management.EKSClusterConfigSpec{
 		AmazonCredentialSecret: cloudCredentialID,
 		DisplayName:            displayName,

--- a/extensions/clusters/gke/create.go
+++ b/extensions/clusters/gke/create.go
@@ -6,8 +6,8 @@ import (
 )
 
 // CreateGKEHostedCluster is a helper function that creates an GKE hosted cluster
-func CreateGKEHostedCluster(client *rancher.Client, displayName, cloudCredentialID string, enableClusterAlerting, enableClusterMonitoring, enableNetworkPolicy, windowsPreferedCluster bool, labels map[string]string) (*management.Cluster, error) {
-	gkeHostCluster := gkeHostClusterConfig(displayName, cloudCredentialID)
+func CreateGKEHostedCluster(client *rancher.Client, displayName, cloudCredentialID string, gkeClusterConfig ClusterConfig, enableClusterAlerting, enableClusterMonitoring, enableNetworkPolicy, windowsPreferedCluster bool, labels map[string]string) (*management.Cluster, error) {
+	gkeHostCluster := gkeHostClusterConfig(displayName, cloudCredentialID, gkeClusterConfig)
 	cluster := &management.Cluster{
 		DockerRootDir:           "/var/lib/docker",
 		GKEConfig:               gkeHostCluster,

--- a/extensions/clusters/gke/gke_cluster_config.go
+++ b/extensions/clusters/gke/gke_cluster_config.go
@@ -2,7 +2,6 @@ package gke
 
 import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/pkg/config"
 )
 
 const (
@@ -228,10 +227,7 @@ func privateClusterConfigBuilder(privateClusterConfig *PrivateClusterConfig) *ma
 	}
 }
 
-func gkeHostClusterConfig(clusterName, cloudCredentialID string) *management.GKEClusterConfigSpec {
-	var gkeClusterConfig ClusterConfig
-	config.LoadConfig(GKEClusterConfigConfigurationFileKey, &gkeClusterConfig)
-
+func gkeHostClusterConfig(clusterName, cloudCredentialID string, gkeClusterConfig ClusterConfig) *management.GKEClusterConfigSpec {
 	return &management.GKEClusterConfigSpec{
 		ClusterAddons:                  clusterAddonsBuilder(gkeClusterConfig.ClusterAddons),
 		ClusterIpv4CidrBlock:           gkeClusterConfig.ClusterIpv4CidrBlock,

--- a/extensions/provisioning/creates.go
+++ b/extensions/provisioning/creates.go
@@ -7,12 +7,15 @@ import (
 	"time"
 
 	"github.com/rancher/norman/types"
+
+	"github.com/sirupsen/logrus"
+
 	"github.com/rancher/shepherd/clients/corral"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/sirupsen/logrus"
 
 	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials/aws"
 	"github.com/rancher/shepherd/extensions/cloudcredentials/azure"
@@ -39,10 +42,11 @@ import (
 	"github.com/rancher/shepherd/pkg/nodes"
 	"github.com/rancher/shepherd/pkg/wait"
 
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
+
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 )
 
 const (
@@ -657,14 +661,14 @@ func CreateProvisioningRKE1AirgapCustomCluster(client *rancher.Client, clustersC
 }
 
 // CreateProvisioningAKSHostedCluster provisions an AKS cluster, then runs verify checks
-func CreateProvisioningAKSHostedCluster(client *rancher.Client) (*management.Cluster, error) {
+func CreateProvisioningAKSHostedCluster(client *rancher.Client, aksClusterConfig aks.ClusterConfig) (*management.Cluster, error) {
 	cloudCredential, err := azure.CreateAzureCloudCredentials(client)
 	if err != nil {
 		return nil, err
 	}
 
 	clusterName := namegen.AppendRandomString("akshostcluster")
-	clusterResp, err := aks.CreateAKSHostedCluster(client, clusterName, cloudCredential.ID, false, false, false, false, nil)
+	clusterResp, err := aks.CreateAKSHostedCluster(client, clusterName, cloudCredential.ID, aksClusterConfig, false, false, false, false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -682,14 +686,14 @@ func CreateProvisioningAKSHostedCluster(client *rancher.Client) (*management.Clu
 }
 
 // CreateProvisioningEKSHostedCluster provisions an EKS cluster, then runs verify checks
-func CreateProvisioningEKSHostedCluster(client *rancher.Client) (*management.Cluster, error) {
+func CreateProvisioningEKSHostedCluster(client *rancher.Client, eksClusterConfig eks.ClusterConfig) (*management.Cluster, error) {
 	cloudCredential, err := aws.CreateAWSCloudCredentials(client)
 	if err != nil {
 		return nil, err
 	}
 
 	clusterName := namegen.AppendRandomString("ekshostcluster")
-	clusterResp, err := eks.CreateEKSHostedCluster(client, clusterName, cloudCredential.ID, false, false, false, false, nil)
+	clusterResp, err := eks.CreateEKSHostedCluster(client, clusterName, cloudCredential.ID, eksClusterConfig, false, false, false, false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -707,14 +711,14 @@ func CreateProvisioningEKSHostedCluster(client *rancher.Client) (*management.Clu
 }
 
 // CreateProvisioningGKEHostedCluster provisions an GKE cluster, then runs verify checks
-func CreateProvisioningGKEHostedCluster(client *rancher.Client) (*management.Cluster, error) {
+func CreateProvisioningGKEHostedCluster(client *rancher.Client, gkeClusterConfig gke.ClusterConfig) (*management.Cluster, error) {
 	cloudCredential, err := google.CreateGoogleCloudCredentials(client)
 	if err != nil {
 		return nil, err
 	}
 
 	clusterName := namegen.AppendRandomString("gkehostcluster")
-	clusterResp, err := gke.CreateGKEHostedCluster(client, clusterName, cloudCredential.ID, false, false, false, false, nil)
+	clusterResp, err := gke.CreateGKEHostedCluster(client, clusterName, cloudCredential.ID, gkeClusterConfig, false, false, false, false, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR modifies the hosted provider create functions to not read directly from the CATTLE_TEST_CONFIG file but obtain the data instead as a user input. This makes the functions more generic and useful when the user needs to run parallel test and the config file needs to be modified during the test, these changes will help in avoiding race condition with the resource.

Note: This is a breaking change PR.
