### PR TITLE
adding support to upgrade out-of-tree charts for rke1 vsphere

### DIFF
--- a/extensions/charts/cisbenchmark.go
+++ b/extensions/charts/cisbenchmark.go
@@ -291,8 +291,8 @@ func UpgradeCISBenchmarkChart(client *rancher.Client, installOptions *InstallOpt
 
 // newCISBenchmarkChartUpgradeAction is a private helper function that returns chart upgrade action.
 func newCISBenchmarkChartUpgradeAction(p *payloadOpts) *types.ChartUpgradeAction {
-	chartUpgrade := newChartUpgrade(p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
-	chartUpgradeCRD := newChartUpgrade(p.Name+"-crd", p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
+	chartUpgrade := newChartUpgrade(p.Name, p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
+	chartUpgradeCRD := newChartUpgrade(p.Name+"-crd", p.Name+"-crd", p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
 	chartUpgrades := []types.ChartUpgrade{*chartUpgradeCRD, *chartUpgrade}
 
 	chartUpgradeAction := newChartUpgradeAction(p.Namespace, chartUpgrades)

--- a/extensions/charts/config.go
+++ b/extensions/charts/config.go
@@ -1,0 +1,9 @@
+package charts
+
+const (
+	ConfigurationFileKey = "chartUpgrade"
+)
+
+type Config struct {
+	IsUpgradable bool `json:"isUpgradable" yaml:"isUpgradable"`
+}

--- a/extensions/charts/payloads.go
+++ b/extensions/charts/payloads.go
@@ -80,14 +80,14 @@ func newChartInstall(name, version, clusterID, clusterName, url, repoName, proje
 }
 
 // newChartUpgradeAction is a private constructor that creates a chart upgrade with given chart values that can be used for chart upgrade action.
-func newChartUpgrade(name, version, clusterID, clusterName, url, defaultRegistry string, chartValues map[string]interface{}) *types.ChartUpgrade {
+func newChartUpgrade(chartName, releaseName, version, clusterID, clusterName, url, defaultRegistry string, chartValues map[string]interface{}) *types.ChartUpgrade {
 	chartUpgrade := types.ChartUpgrade{
 		Annotations: map[string]string{
 			"catalog.cattle.io/ui-source-repo":      "rancher-charts",
 			"catalog.cattle.io/ui-source-repo-type": "cluster",
 		},
-		ChartName:   name,
-		ReleaseName: name,
+		ChartName:   chartName,
+		ReleaseName: releaseName,
 		Version:     version,
 		Values: v3.MapStringInterface{
 			"global": map[string]interface{}{

--- a/extensions/charts/ranchergatekeeper.go
+++ b/extensions/charts/ranchergatekeeper.go
@@ -289,8 +289,8 @@ func UpgradeRancherGatekeeperChart(client *rancher.Client, installOptions *Insta
 
 // newGatekeeperChartUpgradeAction is a private helper function that returns chart upgrade action.
 func newGatekeeperChartUpgradeAction(p *payloadOpts) *types.ChartUpgradeAction {
-	chartUpgrade := newChartUpgrade(p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
-	chartUpgradeCRD := newChartUpgrade(p.Name+"-crd", p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
+	chartUpgrade := newChartUpgrade(p.Name, p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
+	chartUpgradeCRD := newChartUpgrade(p.Name+"-crd", p.Name+"-crd", p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, nil)
 	chartUpgrades := []types.ChartUpgrade{*chartUpgradeCRD, *chartUpgrade}
 
 	chartUpgradeAction := newChartUpgradeAction(p.Namespace, chartUpgrades)

--- a/extensions/charts/rancheristio.go
+++ b/extensions/charts/rancheristio.go
@@ -298,7 +298,7 @@ func newIstioChartUpgradeAction(p *payloadOpts, rancherIstioOpts *RancherIstioOp
 			"enabled": rancherIstioOpts.CNI,
 		},
 	}
-	chartUpgrade := newChartUpgrade(p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, istioValues)
+	chartUpgrade := newChartUpgrade(p.Name, p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, istioValues)
 	chartUpgrades := []types.ChartUpgrade{*chartUpgrade}
 
 	chartUpgradeAction := newChartUpgradeAction(p.Namespace, chartUpgrades)

--- a/extensions/charts/ranchermonitoring.go
+++ b/extensions/charts/ranchermonitoring.go
@@ -332,8 +332,8 @@ func newMonitoringChartUpgradeAction(p *payloadOpts, rancherMonitoringOpts *Ranc
 		monitoringValues[k] = v
 	}
 
-	chartUpgrade := newChartUpgrade(p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, monitoringValues)
-	chartUpgradeCRD := newChartUpgrade(p.Name+"-crd", p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, monitoringValues)
+	chartUpgrade := newChartUpgrade(p.Name, p.Name, p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, monitoringValues)
+	chartUpgradeCRD := newChartUpgrade(p.Name+"-crd", p.Name+"-crd", p.Version, p.Cluster.ID, p.Cluster.Name, p.Host, p.DefaultRegistry, monitoringValues)
 	chartUpgrades := []types.ChartUpgrade{*chartUpgradeCRD, *chartUpgrade}
 
 	chartUpgradeAction := newChartUpgradeAction(p.Namespace, chartUpgrades)

--- a/extensions/charts/vsphereoutoftree.go
+++ b/extensions/charts/vsphereoutoftree.go
@@ -1,10 +1,16 @@
 package charts
 
 import (
+	"context"
+
+	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	rancherv1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/projects"
 	"github.com/rancher/shepherd/extensions/rke1/nodetemplates"
 	"github.com/rancher/shepherd/pkg/api/steve/catalog/types"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/clients/rancher/catalog"
@@ -14,7 +20,9 @@ import (
 const (
 	systemProject       = "System"
 	vsphereCPIchartName = "rancher-vsphere-cpi"
+	manualCPIchartName  = "vsphere-cpi"
 	vsphereCSIchartName = "rancher-vsphere-csi"
+	manualCSIchartName  = "vsphere-csi"
 
 	vcenter      = "vCenter"
 	storageclass = "storageClass"
@@ -28,8 +36,8 @@ const (
 	datastoreurl = "datastoreURL"
 )
 
-// InstallVsphereOutOfTreeCharts installs the CPI and CSI chart for aws cloud provider in a given cluster.
-func InstallVsphereOutOfTreeCharts(client *rancher.Client, vsphereTemplate *nodetemplates.NodeTemplate, repoName, clusterName string) error {
+// InstallVsphereOutOfTreeCharts installs the CPI and CSI chart for vsphere cloud provider in a given cluster.
+func InstallVsphereOutOfTreeCharts(client *rancher.Client, repoName, clusterName string, isLatestVersion bool) error {
 	serverSetting, err := client.Management.Setting.ByID(serverURLSettingID)
 	if err != nil {
 		return err
@@ -55,14 +63,31 @@ func InstallVsphereOutOfTreeCharts(client *rancher.Client, vsphereTemplate *node
 		return err
 	}
 
-	latestCPIVersion, err := catalogClient.GetLatestChartVersion(vsphereCPIchartName, catalog.RancherChartRepo)
+	var cpiVersion string
+	var csiVersion string
+
+	cpiVersions, err := catalogClient.GetListChartVersions(vsphereCPIchartName, catalog.RancherChartRepo)
 	if err != nil {
 		return err
 	}
 
+	cpiVersion = cpiVersions[0]
+
+	csiVersions, err := catalogClient.GetListChartVersions(vsphereCSIchartName, catalog.RancherChartRepo)
+	if err != nil {
+		return err
+	}
+
+	csiVersion = csiVersions[0]
+
+	if !isLatestVersion {
+		cpiVersion = cpiVersions[len(cpiVersions)-1]
+		csiVersion = csiVersions[len(csiVersions)-1]
+	}
+
 	installCPIOptions := &InstallOptions{
 		Cluster:   cluster,
-		Version:   latestCPIVersion,
+		Version:   cpiVersion,
 		ProjectID: project.ID,
 	}
 
@@ -74,30 +99,29 @@ func InstallVsphereOutOfTreeCharts(client *rancher.Client, vsphereTemplate *node
 		DefaultRegistry: registrySetting.Value,
 	}
 
+	vsphereTemplateConfig := r1vsphere.GetVsphereNodeTemplate()
+
 	chartInstallAction, err := vsphereCPIChartInstallAction(catalogClient,
-		chartInstallActionPayload, vsphereTemplate, installCPIOptions, repoName, kubeSystemNamespace)
+		chartInstallActionPayload, vsphereTemplateConfig, installCPIOptions, repoName, kubeSystemNamespace)
 	if err != nil {
 		return err
 	}
 
+	logrus.Infof("executing chart install")
 	err = catalogClient.InstallChart(chartInstallAction, repoName)
 	if err != nil {
 		return err
 	}
 
+	logrus.Infof("verifying chart install")
 	err = VerifyChartInstall(catalogClient, kubeSystemNamespace, vsphereCPIchartName)
-	if err != nil {
-		return err
-	}
-
-	latestCSIVersion, err := catalogClient.GetLatestChartVersion(vsphereCSIchartName, catalog.RancherChartRepo)
 	if err != nil {
 		return err
 	}
 
 	installCSIOptions := &InstallOptions{
 		Cluster:   cluster,
-		Version:   latestCSIVersion,
+		Version:   csiVersion,
 		ProjectID: project.ID,
 	}
 
@@ -110,11 +134,12 @@ func InstallVsphereOutOfTreeCharts(client *rancher.Client, vsphereTemplate *node
 	}
 
 	chartInstallAction, err = vsphereCSIChartInstallAction(catalogClient, chartInstallActionPayload,
-		vsphereTemplate, installCSIOptions, repoName, kubeSystemNamespace)
+		vsphereTemplateConfig, installCSIOptions, repoName, kubeSystemNamespace)
 	if err != nil {
 		return err
 	}
 
+	logrus.Infof("executing chart install")
 	err = catalogClient.InstallChart(chartInstallAction, repoName)
 	if err != nil {
 		return err
@@ -123,18 +148,18 @@ func InstallVsphereOutOfTreeCharts(client *rancher.Client, vsphereTemplate *node
 	return err
 }
 
-// vsphereCPIChartInstallAction is a helper function that returns a chartInstallAction for aws out-of-tree chart.
-func vsphereCPIChartInstallAction(client *catalog.Client, chartInstallActionPayload *payloadOpts, vsphereTemplate *nodetemplates.NodeTemplate, installOptions *InstallOptions, repoName, chartNamespace string) (*types.ChartInstallAction, error) {
+// vsphereCPIChartInstallAction is a helper function that returns a chartInstallAction for vsphere out-of-tree chart.
+func vsphereCPIChartInstallAction(client *catalog.Client, chartInstallActionPayload *payloadOpts, vsphereTemplateConfig *nodetemplates.VmwareVsphereNodeTemplateConfig, installOptions *InstallOptions, repoName, chartNamespace string) (*types.ChartInstallAction, error) {
 	chartValues, err := client.GetChartValues(repoName, vsphereCPIchartName, installOptions.Version)
 	if err != nil {
 		return nil, err
 	}
 
-	chartValues[vcenter].(map[string]interface{})[datacenters] = vsphereTemplate.VmwareVsphereNodeTemplateConfig.Datacenter
-	chartValues[vcenter].(map[string]interface{})[host] = vsphereTemplate.VmwareVsphereNodeTemplateConfig.Vcenter
-	chartValues[vcenter].(map[string]interface{})[password] = r1vsphere.GetVspherePassword()
-	chartValues[vcenter].(map[string]interface{})[username] = vsphereTemplate.VmwareVsphereNodeTemplateConfig.Username
-	chartValues[vcenter].(map[string]interface{})[port] = vsphereTemplate.VmwareVsphereNodeTemplateConfig.VcenterPort
+	chartValues[vcenter].(map[string]interface{})[datacenters] = vsphereTemplateConfig.Datacenter
+	chartValues[vcenter].(map[string]interface{})[host] = vsphereTemplateConfig.Vcenter
+	chartValues[vcenter].(map[string]interface{})[password] = vsphereTemplateConfig.Password
+	chartValues[vcenter].(map[string]interface{})[username] = vsphereTemplateConfig.Username
+	chartValues[vcenter].(map[string]interface{})[port] = vsphereTemplateConfig.VcenterPort
 
 	chartInstall := newChartInstall(
 		chartInstallActionPayload.Name,
@@ -151,21 +176,21 @@ func vsphereCPIChartInstallAction(client *catalog.Client, chartInstallActionPayl
 	return newChartInstallAction(chartNamespace, chartInstallActionPayload.ProjectID, chartInstalls), nil
 }
 
-// vsphereCSIChartInstallAction is a helper function that returns a chartInstallAction for aws out-of-tree chart.
-func vsphereCSIChartInstallAction(client *catalog.Client, chartInstallActionPayload *payloadOpts, vsphereTemplate *nodetemplates.NodeTemplate, installOptions *InstallOptions, repoName, chartNamespace string) (*types.ChartInstallAction, error) {
+// vsphereCSIChartInstallAction is a helper function that returns a chartInstallAction for vsphere out-of-tree chart.
+func vsphereCSIChartInstallAction(client *catalog.Client, chartInstallActionPayload *payloadOpts, vsphereTemplateConfig *nodetemplates.VmwareVsphereNodeTemplateConfig, installOptions *InstallOptions, repoName, chartNamespace string) (*types.ChartInstallAction, error) {
 	chartValues, err := client.GetChartValues(repoName, vsphereCSIchartName, installOptions.Version)
 	if err != nil {
 		return nil, err
 	}
 
-	chartValues[vcenter].(map[string]interface{})[datacenters] = vsphereTemplate.VmwareVsphereNodeTemplateConfig.Datacenter
-	chartValues[vcenter].(map[string]interface{})[host] = vsphereTemplate.VmwareVsphereNodeTemplateConfig.Vcenter
-	chartValues[vcenter].(map[string]interface{})[password] = r1vsphere.GetVspherePassword()
-	chartValues[vcenter].(map[string]interface{})[username] = vsphereTemplate.VmwareVsphereNodeTemplateConfig.Username
-	chartValues[vcenter].(map[string]interface{})[port] = vsphereTemplate.VmwareVsphereNodeTemplateConfig.VcenterPort
+	chartValues[vcenter].(map[string]interface{})[datacenters] = vsphereTemplateConfig.Datacenter
+	chartValues[vcenter].(map[string]interface{})[host] = vsphereTemplateConfig.Vcenter
+	chartValues[vcenter].(map[string]interface{})[password] = vsphereTemplateConfig.Password
+	chartValues[vcenter].(map[string]interface{})[username] = vsphereTemplateConfig.Username
+	chartValues[vcenter].(map[string]interface{})[port] = vsphereTemplateConfig.VcenterPort
 	chartValues[vcenter].(map[string]interface{})[clusterid] = installOptions.Cluster.ID
 
-	chartValues[storageclass].(map[string]interface{})[datastoreurl] = r1vsphere.GetVsphereDatastoreURL()
+	chartValues[storageclass].(map[string]interface{})[datastoreurl] = vsphereTemplateConfig.DatastoreURL
 
 	chartInstall := newChartInstall(
 		chartInstallActionPayload.Name,
@@ -180,4 +205,224 @@ func vsphereCSIChartInstallAction(client *catalog.Client, chartInstallActionPayl
 	chartInstalls := []types.ChartInstall{*chartInstall}
 
 	return newChartInstallAction(chartNamespace, chartInstallActionPayload.ProjectID, chartInstalls), nil
+}
+
+// UpgradeVsphereOutOfTreeCharts upgrades the CPI and CSI chart for vsphere cloud provider in a given cluster to the latest version.
+func UpgradeVsphereOutOfTreeCharts(client *rancher.Client, repoName, clusterName string) error {
+	serverSetting, err := client.Management.Setting.ByID(serverURLSettingID)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := clusters.NewClusterMeta(client, clusterName)
+	if err != nil {
+		return err
+	}
+
+	registrySetting, err := client.Management.Setting.ByID(defaultRegistrySettingID)
+	if err != nil {
+		return err
+	}
+
+	project, err := projects.GetProjectByName(client, cluster.ID, systemProject)
+	if err != nil {
+		return err
+	}
+
+	catalogClient, err := client.GetClusterCatalogClient(cluster.ID)
+	if err != nil {
+		return err
+	}
+
+	cpiChartName := vsphereCPIchartName
+	cpiVersion, err := catalogClient.GetLatestChartVersion(cpiChartName, catalog.RancherChartRepo)
+	if err != nil {
+		return err
+	}
+
+	csiChartName := vsphereCSIchartName
+	csiVersion, err := catalogClient.GetLatestChartVersion(csiChartName, catalog.RancherChartRepo)
+	if err != nil {
+		return err
+	}
+
+	cpiChartObject, err := getExistingChartInstall(catalogClient, cpiChartName, kubeSystemNamespace)
+	if err != nil {
+		cpiChartName = manualCPIchartName
+		cpiChartObject, err = getExistingChartInstall(catalogClient, cpiChartName, kubeSystemNamespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	cpiSpec := new(v1.ReleaseSpec)
+	err = rancherv1.ConvertToK8sType(cpiChartObject.Spec, &cpiSpec)
+	if err != nil {
+		return err
+	}
+
+	csiChartObject, err := getExistingChartInstall(catalogClient, csiChartName, kubeSystemNamespace)
+	if err != nil {
+		csiChartName = manualCSIchartName
+		csiChartObject, err = getExistingChartInstall(catalogClient, csiChartName, kubeSystemNamespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	csiSpec := new(v1.ReleaseSpec)
+	err = rancherv1.ConvertToK8sType(csiChartObject.Spec, &csiSpec)
+	if err != nil {
+		return err
+	}
+
+	if cpiVersion != cpiSpec.Chart.Metadata.Version {
+		installCPIOptions := &InstallOptions{
+			Cluster:   cluster,
+			Version:   cpiVersion,
+			ProjectID: project.ID,
+		}
+
+		chartInstallActionPayload := &payloadOpts{
+			InstallOptions:  *installCPIOptions,
+			Name:            cpiChartName,
+			Namespace:       kubeSystemNamespace,
+			Host:            serverSetting.Value,
+			DefaultRegistry: registrySetting.Value,
+		}
+
+		vsphereConfig := r1vsphere.GetVsphereNodeTemplate()
+
+		chartUpgradeAction, err := vsphereCPIChartUpgradeAction(catalogClient,
+			chartInstallActionPayload, vsphereConfig, repoName, kubeSystemNamespace)
+		if err != nil {
+			return err
+		}
+
+		err = catalogClient.UpgradeChart(chartUpgradeAction, repoName)
+		if err != nil {
+			return err
+		}
+
+		err = VerifyChartUpgrade(catalogClient, kubeSystemNamespace, cpiChartName, cpiVersion)
+		if err != nil {
+			return err
+		}
+	} else {
+		logrus.Infof(
+			"No chart version to upgrade to, already on the latest CPI version: %s vs installed %s",
+			cpiVersion,
+			cpiSpec.Chart.Metadata.Version)
+	}
+
+	if csiVersion != csiSpec.Chart.Metadata.Version {
+		installCSIOptions := &InstallOptions{
+			Cluster:   cluster,
+			Version:   csiVersion,
+			ProjectID: project.ID,
+		}
+
+		chartInstallActionPayload := &payloadOpts{
+			InstallOptions:  *installCSIOptions,
+			Name:            csiChartName,
+			Namespace:       kubeSystemNamespace,
+			Host:            serverSetting.Value,
+			DefaultRegistry: registrySetting.Value,
+		}
+
+		vsphereConfig := r1vsphere.GetVsphereNodeTemplate()
+
+		chartUpgradeAction, err := vsphereCSIChartUpgradeAction(catalogClient, chartInstallActionPayload,
+			vsphereConfig, repoName, kubeSystemNamespace)
+		if err != nil {
+			return err
+		}
+
+		logrus.Infof("executing chart upgrade")
+		err = catalogClient.UpgradeChart(chartUpgradeAction, repoName)
+		if err != nil {
+			return err
+		}
+
+		logrus.Infof("verifying chart upgrade")
+		err = VerifyChartUpgrade(catalogClient, kubeSystemNamespace, csiChartName, csiVersion)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		logrus.Infof(
+			"No chart version to upgrade to, already on the latest CSI version: %s vs installed %s",
+			csiVersion,
+			csiSpec.Chart.Metadata.Version)
+	}
+
+	return err
+}
+
+// vsphereCPIChartUpgradeAction is a helper function that returns a chartUpgradeAction for vsphere out-of-tree chart.
+func vsphereCPIChartUpgradeAction(client *catalog.Client, chartUpgradeActionPayload *payloadOpts, vsphereTemplateConfig *nodetemplates.VmwareVsphereNodeTemplateConfig, repoName, chartNamespace string) (*types.ChartUpgradeAction, error) {
+	chartValues, err := client.GetChartValues(repoName, chartUpgradeActionPayload.Name, chartUpgradeActionPayload.InstallOptions.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	chartValues[vcenter].(map[string]interface{})[datacenters] = vsphereTemplateConfig.Datacenter
+	chartValues[vcenter].(map[string]interface{})[host] = vsphereTemplateConfig.Vcenter
+	chartValues[vcenter].(map[string]interface{})[password] = vsphereTemplateConfig.Password
+	chartValues[vcenter].(map[string]interface{})[username] = vsphereTemplateConfig.Username
+	chartValues[vcenter].(map[string]interface{})[port] = vsphereTemplateConfig.VcenterPort
+
+	chartUpgrade := newChartUpgrade(
+		vsphereCPIchartName,
+		chartUpgradeActionPayload.Name,
+		chartUpgradeActionPayload.Version,
+		chartUpgradeActionPayload.Cluster.ID,
+		chartUpgradeActionPayload.Cluster.Name,
+		repoName,
+		chartUpgradeActionPayload.DefaultRegistry,
+		chartValues)
+	chartUpgrades := []types.ChartUpgrade{*chartUpgrade}
+
+	return newChartUpgradeAction(chartNamespace, chartUpgrades), nil
+}
+
+// vsphereCSIChartUpgradeAction is a helper function that returns a chartUpgradeAction for vsphere out-of-tree chart.
+func vsphereCSIChartUpgradeAction(client *catalog.Client, chartUpgradeActionPayload *payloadOpts, vsphereTemplateConfig *nodetemplates.VmwareVsphereNodeTemplateConfig, repoName, chartNamespace string) (*types.ChartUpgradeAction, error) {
+	chartValues, err := client.GetChartValues(repoName, vsphereCSIchartName, chartUpgradeActionPayload.InstallOptions.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	chartValues[vcenter].(map[string]interface{})[datacenters] = vsphereTemplateConfig.Datacenter
+	chartValues[vcenter].(map[string]interface{})[host] = vsphereTemplateConfig.Vcenter
+	chartValues[vcenter].(map[string]interface{})[password] = vsphereTemplateConfig.Password
+	chartValues[vcenter].(map[string]interface{})[username] = vsphereTemplateConfig.Username
+	chartValues[vcenter].(map[string]interface{})[port] = vsphereTemplateConfig.VcenterPort
+	chartValues[vcenter].(map[string]interface{})[clusterid] = chartUpgradeActionPayload.InstallOptions.Cluster.ID
+
+	chartValues[storageclass].(map[string]interface{})[datastoreurl] = vsphereTemplateConfig.DatastoreURL
+
+	chartUpgrade := newChartUpgrade(
+		vsphereCSIchartName,
+		chartUpgradeActionPayload.Name,
+		chartUpgradeActionPayload.Version,
+		chartUpgradeActionPayload.Cluster.ID,
+		chartUpgradeActionPayload.Cluster.Name,
+		repoName,
+		chartUpgradeActionPayload.DefaultRegistry,
+		chartValues)
+	chartUpgrades := []types.ChartUpgrade{*chartUpgrade}
+
+	return newChartUpgradeAction(chartNamespace, chartUpgrades), nil
+}
+
+// getExistingChartInstall returns the App object of an installed chart.
+func getExistingChartInstall(client *catalog.Client, chartName, chartNamespace string) (*v1.App, error) {
+	appObject, err := client.Apps(chartNamespace).Get(context.TODO(), chartName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return appObject, nil
 }

--- a/extensions/rke1/nodetemplates/vsphere/create.go
+++ b/extensions/rke1/nodetemplates/vsphere/create.go
@@ -11,7 +11,7 @@ import (
 const vmwarevsphereNodeTemplateNameBase = "vmwarevsphereNodeConfig"
 
 // CreateVSphereNodeTemplate is a helper function that takes the rancher Client as a parameter and creates
-// an VSphere node template and returns the NodeTemplate response
+// a VSphere node template and returns the NodeTemplate response
 func CreateVSphereNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.NodeTemplate, error) {
 	var vmwarevsphereNodeTemplateConfig nodetemplates.VmwareVsphereNodeTemplateConfig
 	config.LoadConfig(nodetemplates.VmwareVsphereNodeTemplateConfigurationFileKey, &vmwarevsphereNodeTemplateConfig)
@@ -49,20 +49,10 @@ func CreateVSphereNodeTemplate(rancherClient *rancher.Client) (*nodetemplates.No
 	return resp, nil
 }
 
-// GetVsphereDatastoreURL is a helper to get the datastoreURL from the cloud credential object as a string
-func GetVsphereDatastoreURL() string {
+// GetVsphereNodeTemplate is a helper to get the vsphere node template from a config
+func GetVsphereNodeTemplate() *nodetemplates.VmwareVsphereNodeTemplateConfig {
 	var vmwarevsphereNodeTemplateConfig nodetemplates.VmwareVsphereNodeTemplateConfig
-
 	config.LoadConfig(nodetemplates.VmwareVsphereNodeTemplateConfigurationFileKey, &vmwarevsphereNodeTemplateConfig)
 
-	return vmwarevsphereNodeTemplateConfig.DatastoreURL
-}
-
-// GetVspherePassword is a helper to get the password from the cloud credential object as a string
-func GetVspherePassword() string {
-	var vmwarevsphereNodeTemplateConfig nodetemplates.VmwareVsphereNodeTemplateConfig
-
-	config.LoadConfig(nodetemplates.VmwareVsphereNodeTemplateConfigurationFileKey, &vmwarevsphereNodeTemplateConfig)
-
-	return vmwarevsphereNodeTemplateConfig.Password
+	return &vmwarevsphereNodeTemplateConfig
 }

--- a/extensions/rke1/nodetemplates/vsphere_config.go
+++ b/extensions/rke1/nodetemplates/vsphere_config.go
@@ -15,7 +15,7 @@ type VmwareVsphereNodeTemplateConfig struct {
 	CustomAttribute       []string `json:"customAttribute" yaml:"customAttribute"`
 	Datacenter            string   `json:"datacenter" yaml:"datacenter"`
 	Datastore             string   `json:"datastore" yaml:"datastore"`
-	DatastoreURL          string   `json:"datatoreURL" yaml:"datastoreURL"`
+	DatastoreURL          string   `json:"datastoreURL" yaml:"datastoreURL"`
 	DatastoreCluster      string   `json:"datastoreCluster" yaml:"datastoreCluster"`
 	DiskSize              string   `json:"diskSize" yaml:"diskSize"`
 	Folder                string   `json:"folder" yaml:"folder"`


### PR DESCRIPTION
supports: https://github.com/rancher/rancher/pull/45792

updated the way that pulling data from the vsphereConfig works, and added some functionality around upgrading + validating charts. 
