### PR TITLE
[v2.10] Update LoadUpgradeKubernetesConfig for upgrade refactor

### DIFF
--- a/extensions/clusters/clusters.go
+++ b/extensions/clusters/clusters.go
@@ -10,9 +10,11 @@ import (
 	"github.com/rancher/norman/types"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/provisioninginput"
@@ -221,7 +223,7 @@ func CreateRancherBaselinePSACT(client *rancher.Client, psact string) error {
 	return nil
 }
 
-// NewRKE1lusterConfig is a constructor for a v3.Cluster object, to be used by the rancher.Client.Provisioning client.
+// NewRKE1ClusterConfig is a constructor for a v3.Cluster object, to be used by the rancher.Client.Provisioning client.
 func NewRKE1ClusterConfig(clusterName string, client *rancher.Client, clustersConfig *ClusterConfig) *management.Cluster {
 	backupConfigEnabled := true
 	criDockerBool := false
@@ -283,6 +285,62 @@ func NewRKE1ClusterConfig(clusterName string, client *rancher.Client, clustersCo
 							ExtraEnv: extraEnv,
 						},
 					}
+					break
+				}
+			}
+		}
+	}
+
+	if clustersConfig.CloudProvider != "" {
+		newConfig.RancherKubernetesEngineConfig.CloudProvider = &management.CloudProvider{
+			Name: clustersConfig.CloudProvider,
+		}
+		if clustersConfig.CloudProvider == externalAws {
+			trueBoolean := true
+			newConfig.RancherKubernetesEngineConfig.CloudProvider.UseInstanceMetadataHostname = &trueBoolean
+		}
+	}
+
+	if clustersConfig.ETCDRKE1 != nil {
+		newConfig.RancherKubernetesEngineConfig.Services.Etcd = clustersConfig.ETCDRKE1
+	}
+
+	if clustersConfig.PSACT != "" {
+		newConfig.DefaultPodSecurityAdmissionConfigurationTemplateName = clustersConfig.PSACT
+	}
+
+	return newConfig
+}
+
+// UpdateRKE1ClusterConfig is a constructor for a v3.Cluster object, to be used by the rancher.Client.Provisioning client.
+func UpdateRKE1ClusterConfig(clusterName string, client *rancher.Client, clustersConfig *ClusterConfig) *management.Cluster {
+	newConfig := &management.Cluster{
+		Name: clusterName,
+		RancherKubernetesEngineConfig: &management.RancherKubernetesEngineConfig{
+			Network: &management.NetworkConfig{
+				Plugin: clustersConfig.CNI,
+			},
+			Version: clustersConfig.KubernetesVersion,
+		},
+	}
+
+	newConfig.ClusterAgentDeploymentCustomization = clustersConfig.ClusterAgent
+	newConfig.FleetAgentDeploymentCustomization = clustersConfig.FleetAgent
+
+	if clustersConfig.Registries != nil {
+		if clustersConfig.Registries.RKE1Registries != nil {
+			newConfig.RancherKubernetesEngineConfig.PrivateRegistries = clustersConfig.Registries.RKE1Registries
+			for _, registry := range clustersConfig.Registries.RKE1Registries {
+				if registry.ECRCredentialPlugin != nil {
+					awsAccessKeyID := fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", registry.ECRCredentialPlugin.AwsAccessKeyID)
+					awsSecretAccessKey := fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", registry.ECRCredentialPlugin.AwsSecretAccessKey)
+					extraEnv := []string{awsAccessKeyID, awsSecretAccessKey}
+					newConfig.RancherKubernetesEngineConfig.Services = &management.RKEConfigServices{
+						Kubelet: &management.KubeletService{
+							ExtraEnv: extraEnv,
+						},
+					}
+
 					break
 				}
 			}
@@ -472,6 +530,116 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace string, clustersConfig *Clus
 	}
 
 	return v1Cluster
+}
+
+// UpdateK3SRKE2ClusterConfig is a constructor for a apisV1.Cluster object, to be used by the rancher.Client.Provisioning client.
+func UpdateK3SRKE2ClusterConfig(cluster *v1.SteveAPIObject, clustersConfig *ClusterConfig) *v1.SteveAPIObject {
+	clusterSpec := &provv1.ClusterSpec{}
+	err := steveV1.ConvertToK8sType(cluster.Spec, clusterSpec)
+	if err != nil {
+		return nil
+	}
+
+	if clustersConfig.ETCD != nil {
+		clusterSpec.RKEConfig.ETCD = clustersConfig.ETCD
+	}
+
+	if clustersConfig.KubernetesVersion != "" {
+		clusterSpec.KubernetesVersion = clustersConfig.KubernetesVersion
+	}
+
+	if clustersConfig.CNI != "" {
+		clusterSpec.RKEConfig.MachineGlobalConfig.Data["cni"] = clustersConfig.CNI
+	}
+
+	if clustersConfig.AddOnConfig != nil {
+		if clustersConfig.AddOnConfig.ChartValues != nil {
+			clusterSpec.RKEConfig.ChartValues = *clustersConfig.AddOnConfig.ChartValues
+		}
+		clusterSpec.RKEConfig.AdditionalManifest = clustersConfig.AddOnConfig.AdditionalManifest
+	}
+
+	if clustersConfig.Advanced != nil {
+		if clustersConfig.Advanced.MachineGlobalConfig != nil {
+			for k, v := range clustersConfig.Advanced.MachineGlobalConfig.Data {
+				clusterSpec.RKEConfig.MachineGlobalConfig.Data[k] = v
+			}
+		}
+
+		if clustersConfig.Advanced.MachineSelectors != nil {
+			clusterSpec.RKEConfig.MachineSelectorConfig = *clustersConfig.Advanced.MachineSelectors
+		}
+	}
+
+	if clustersConfig.Networking != nil {
+		if clustersConfig.Networking.LocalClusterAuthEndpoint != nil {
+			clusterSpec.LocalClusterAuthEndpoint = *clustersConfig.Networking.LocalClusterAuthEndpoint
+		}
+	}
+
+	if clustersConfig.UpgradeStrategy != nil {
+		clusterSpec.RKEConfig.UpgradeStrategy = *clustersConfig.UpgradeStrategy
+	}
+
+	if clustersConfig.ClusterAgent != nil {
+		clusterAgentOverrides := ResourceConfigHelper(clustersConfig.ClusterAgent.OverrideResourceRequirements)
+		clusterSpec.ClusterAgentDeploymentCustomization.OverrideResourceRequirements = clusterAgentOverrides
+		v1ClusterTolerations := []corev1.Toleration{}
+		for _, t := range clustersConfig.ClusterAgent.AppendTolerations {
+			v1ClusterTolerations = append(v1ClusterTolerations, corev1.Toleration{
+				Key:      t.Key,
+				Operator: corev1.TolerationOperator(t.Operator),
+				Value:    t.Value,
+				Effect:   corev1.TaintEffect(t.Effect),
+			})
+		}
+		clusterSpec.ClusterAgentDeploymentCustomization.AppendTolerations = v1ClusterTolerations
+		clusterSpec.ClusterAgentDeploymentCustomization.OverrideAffinity = AgentAffinityConfigHelper(clustersConfig.ClusterAgent.OverrideAffinity)
+	}
+
+	if clustersConfig.FleetAgent != nil {
+		fleetAgentOverrides := ResourceConfigHelper(clustersConfig.FleetAgent.OverrideResourceRequirements)
+		clusterSpec.ClusterAgentDeploymentCustomization.OverrideResourceRequirements = fleetAgentOverrides
+		v1FleetTolerations := []corev1.Toleration{}
+		for _, t := range clustersConfig.FleetAgent.AppendTolerations {
+			v1FleetTolerations = append(v1FleetTolerations, corev1.Toleration{
+				Key:      t.Key,
+				Operator: corev1.TolerationOperator(t.Operator),
+				Value:    t.Value,
+				Effect:   corev1.TaintEffect(t.Effect),
+			})
+		}
+		clusterSpec.FleetAgentDeploymentCustomization.AppendTolerations = v1FleetTolerations
+		clusterSpec.FleetAgentDeploymentCustomization.OverrideAffinity = AgentAffinityConfigHelper(clustersConfig.FleetAgent.OverrideAffinity)
+	}
+
+	if clustersConfig.Registries != nil {
+		clusterSpec.RKEConfig.Registries = clustersConfig.Registries.RKE2Registries
+	}
+
+	if clustersConfig.CloudProvider == provisioninginput.AWSProviderName.String() {
+		clusterSpec.RKEConfig.MachineSelectorConfig = append(clusterSpec.RKEConfig.MachineSelectorConfig, OutOfTreeSystemConfig(clustersConfig.CloudProvider)...)
+	} else if strings.Contains(clustersConfig.CloudProvider, "-in-tree") {
+		clusterSpec.RKEConfig.MachineSelectorConfig = append(clusterSpec.RKEConfig.MachineSelectorConfig, InTreeSystemConfig(strings.Split(clustersConfig.CloudProvider, "-in-tree")[0])...)
+	}
+
+	if clustersConfig.CloudProvider == provisioninginput.VsphereCloudProviderName.String() {
+		clusterSpec.RKEConfig.MachineSelectorConfig = append(clusterSpec.RKEConfig.MachineSelectorConfig,
+			RKESystemConfigTemplate(map[string]interface{}{
+				cloudProviderAnnotationName: provisioninginput.VsphereCloudProviderName.String(),
+				protectKernelDefaults:       false,
+			},
+				nil),
+		)
+	}
+
+	if clustersConfig.PSACT != "" {
+		clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName = clustersConfig.PSACT
+	}
+
+	cluster.Spec = clusterSpec
+
+	return cluster
 }
 
 // OutOfTreeSystemConfig constructs the proper rkeSystemConfig slice for enabling the aws cloud provider
@@ -1058,6 +1226,38 @@ func DeleteK3SRKE2Cluster(client *rancher.Client, clusterID string) error {
 	}
 
 	return nil
+}
+
+// UpdateRKE1Cluster is a "helper" functions that takes a rancher client, old rke1 cluster config, and the new rke1 cluster config as parameters.
+func UpdateRKE1Cluster(client *rancher.Client, cluster, updatedCluster *management.Cluster) (*management.Cluster, error) {
+	logrus.Infof("Updating cluster...")
+	newCluster, err := client.Management.Cluster.Update(cluster, updatedCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	err = kwait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, defaults.ThirtyMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
+		client, err = client.ReLogin()
+		if err != nil {
+			return false, err
+		}
+
+		clusterResp, err := client.Management.Cluster.ByID(newCluster.ID)
+		if err != nil {
+			return false, err
+		}
+
+		if clusterResp.State == active {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
 }
 
 // UpdateK3SRKE2Cluster is a "helper" functions that takes a rancher client, old rke2/k3s cluster config, and the new rke2/k3s cluster config as parameters.

--- a/extensions/upgradeinput/config.go
+++ b/extensions/upgradeinput/config.go
@@ -1,5 +1,7 @@
 package upgradeinput
 
+import "github.com/rancher/shepherd/extensions/provisioninginput"
+
 type PSACT string
 
 const (
@@ -15,12 +17,10 @@ type Config struct {
 
 // Cluster is a struct that's used to configure a single cluster to be used in an upgrade test
 type Cluster struct {
-	Name              string   `json:"name" yaml:"name" default:""`
-	VersionToUpgrade  string   `json:"versionToUpgrade" yaml:"versionToUpgrade" default:""`
-	PSACT             string   `json:"psact" yaml:"psact" default:""`
-	FeaturesToTest    Features `json:"enabledFeatures" yaml:"enabledFeatures" default:""`
-	IsLatestVersion   bool
-	IsUpgradeDisabled bool
+	Name              string                   `json:"name" yaml:"name" default:""`
+	VersionToUpgrade  string                   `json:"versionToUpgrade" yaml:"versionToUpgrade" default:""`
+	FeaturesToTest    Features                 `json:"enabledFeatures" yaml:"enabledFeatures" default:""`
+	ProvisioningInput provisioninginput.Config `json:"provisioningInput" yaml:"provisioningInput"`
 }
 
 // Features is a struct that stores test case options for a single cluster

--- a/extensions/upgradeinput/load.go
+++ b/extensions/upgradeinput/load.go
@@ -38,63 +38,6 @@ func LoadUpgradeKubernetesConfig(client *rancher.Client) (clusters []Cluster, er
 			cluster := new(Cluster)
 
 			cluster.Name = clusterList[i]
-			cluster.IsLatestVersion = true
-
-			clusters = append(clusters, *cluster)
-		}
-	} else if isUpgradeSomeClusters {
-		for _, c := range upgradeConfig.Clusters {
-			cluster := new(Cluster)
-
-			cluster.Name = c.Name
-			cluster.VersionToUpgrade = c.VersionToUpgrade
-			cluster.PSACT = c.PSACT
-
-			isVersionFieldLatest := cluster.VersionToUpgrade == LatestKey
-			if isVersionFieldLatest {
-				cluster.IsLatestVersion = true
-			}
-
-			isUpgradeDisabled := cluster.VersionToUpgrade == ""
-			if isUpgradeDisabled {
-				cluster.IsUpgradeDisabled = true
-			}
-
-			clusters = append(clusters, *cluster)
-		}
-	}
-
-	return
-}
-
-// loadUpgradeKubernetesConfig is a test helper function to get required slice of Clusters struct. Returns error if any.
-// Contains two different config options to workload upgrade test:
-//  1. A flag called “all” is only requirement, tests all clusters with ingrss and charts options disabled
-//  2. Some option that's up to user input
-func LoadUpgradeWorkloadConfig(client *rancher.Client) (clusters []Cluster, err error) {
-	upgradeConfig := new(Config)
-	config.LoadConfig(ConfigurationFileKey, upgradeConfig)
-
-	isConfigEmpty := len(upgradeConfig.Clusters) == 0
-	isFlagDeclared := client.Flags.GetValue(environmentflag.WorkloadUpgradeAllClusters)
-
-	if isConfigEmpty && !isFlagDeclared {
-		return clusters, errors.Wrap(err, "config doesn't match the requirements")
-	}
-
-	isUpgradeAllClusters := isFlagDeclared && isConfigEmpty
-	isUpgradeSomeClusters := !isConfigEmpty && !isUpgradeAllClusters
-
-	if isUpgradeAllClusters {
-		clusterList, err := listDownstreamClusters(client)
-		if err != nil {
-			return clusters, errors.Wrap(err, "couldn't list clusters")
-		}
-
-		for i := range clusterList {
-			cluster := new(Cluster)
-
-			cluster.Name = clusterList[i]
 			ingress := false
 			chart := false
 			cluster.FeaturesToTest = Features{
@@ -109,8 +52,8 @@ func LoadUpgradeWorkloadConfig(client *rancher.Client) (clusters []Cluster, err 
 			cluster := new(Cluster)
 
 			cluster.Name = c.Name
+			cluster.ProvisioningInput = c.ProvisioningInput
 			cluster.FeaturesToTest = c.FeaturesToTest
-			cluster.PSACT = c.PSACT
 
 			clusters = append(clusters, *cluster)
 		}


### PR DESCRIPTION
### Issue: [Refactor upgrading package to follow current best practices](https://github.com/rancher/qa-tasks/issues/1395)

### PR Description
As part of the QA task, we are refactoring the upgrading package to follow the best practices that packages such as `provisioning` and `snapshot` follow. When refactoring, it was agreed upon to have `kubernetes_test.go` perform the pre and post upgrade checks instead of `workload_test.go`. That way, one test runs all of the operations.

How it currently is, you have to run 3 individual tests that all pertain to one Kubernetes upgrade. This is being addressed in the r/r PR. For shepherd, we need to update the `LoadUpgradeKubernetesConfig` to ensure that the parameters found in `LoadUpgradeWorkloadsConfig` are being referenced.

This way, the `kubernetes_test.go` does not need to have to call two separate configs, which is making the refactor overly complicated.