### PR TITLE
Adjust steps, do allow more time to load the schema.

### DIFF
--- a/clients/rancher/v1/client.go
+++ b/clients/rancher/v1/client.go
@@ -23,7 +23,7 @@ const (
 	hostRegex = "https://(.+)/v1"
 	duration  = 100 * time.Millisecond // duration of 100 miliseconds to be short since this is a fast check
 	factor    = 2                      // with a factor of 1
-	steps     = 8                      // only do 8 tries
+	steps     = 12                     // only do 12 tries
 )
 
 // State is the Steve specific field in the rancher Steve API
@@ -118,7 +118,7 @@ func NewClient(opts *clientbase.ClientOpts) (*Client, error) {
 		if previousTypesLength == typesLength {
 			count += 1
 		}
-		if count > 3 {
+		if count > 4 {
 			return true, nil
 		}
 


### PR DESCRIPTION
This is to give the client more of chance to make sure the schema has been successfully loaded.