### PR TITLE
Refactor context to store session for downstream context creation

### DIFF
--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -81,6 +81,7 @@ type Context struct {
 	apps *apps.Factory
 	core *core.Factory
 
+	session *session.Session
 	started bool
 }
 
@@ -194,9 +195,10 @@ func NewContext(ctx context.Context, restConfig *rest.Config, ts *session.Sessio
 		ControllerFactory:       controllerFactory,
 		controllerLock:          &sync.Mutex{},
 
-		mgmt: mgmt,
-		apps: apps,
-		core: core,
+		mgmt:    mgmt,
+		apps:    apps,
+		core:    core,
+		session: ts,
 	}
 
 	return wContext, nil
@@ -258,7 +260,7 @@ func (w *Context) DownStreamClusterWranglerContext(clusterID string) (*Context, 
 	restConfig := *w.RESTConfig
 	restConfig.Host = fmt.Sprintf("https://%s/k8s/clusters/%s", w.RESTConfig.Host, clusterID)
 
-	clusterContext, err := NewContext(context.TODO(), &restConfig, nil)
+	clusterContext, err := NewContext(context.TODO(), &restConfig, w.session)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://github.com/rancher/qa-tasks/issues/1443

**Issue**:
The DownStreamClusterWranglerContext function is currently not handling sessions correctly. When this function is called, it passes nil for the session parameter, resulting in a panic when objects are created on the downstream cluster using wrangler client.

**Solution**:

- Add a session attribute to the Context struct
- Update the NewContext function to initialize the session attribute
- Modify DownStreamClusterWranglerContext to use the stored session

**2.8 Backport PR**: https://github.com/rancher/shepherd/pull/244