### PR TITLE
<main> Fixed pod logs streaming error

### DIFF
--- a/extensions/kubectl/command.go
+++ b/extensions/kubectl/command.go
@@ -96,7 +96,11 @@ func Command(client *rancher.Client, yamlContent *management.ImportClusterYamlIn
 		return "", err
 	}
 
-	steveClient := client.Steve
+	steveClient, err := client.Steve.ProxyDownstream(clusterID)
+	if err != nil {
+		return "", err
+	}
+
 	pods, err := steveClient.SteveType(pods.PodResourceSteveType).NamespacedSteveClient(Namespace).List(nil)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Changed kubectl Command function to use a ProxyDownstream steve cliente by cluster

Backports:
[v2.9](https://github.com/rancher/shepherd/pull/266)
[v2.8](https://github.com/rancher/shepherd/pull/268)
[v2.7](https://github.com/rancher/shepherd/pull/267)