### PR TITLE
[2.9] Credentials update

### DIFF
--- a/extensions/cloudcredentials/aws/create.go
+++ b/extensions/cloudcredentials/aws/create.go
@@ -2,28 +2,43 @@ package aws
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
-	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/extensions/steve"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const awsCloudCredNameBase = "awsCloudCredential"
-
-// CreateAWSCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
-// an AWS cloud credential, and returns the CloudCredential response
-func CreateAWSCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
-	var amazonEC2CredentialConfig cloudcredentials.AmazonEC2CredentialConfig
-	config.LoadConfig(cloudcredentials.AmazonEC2CredentialConfigurationFileKey, &amazonEC2CredentialConfig)
-
-	cloudCredential := cloudcredentials.CloudCredential{
-		Name:                      awsCloudCredNameBase,
-		AmazonEC2CredentialConfig: &amazonEC2CredentialConfig,
+// CreateAWSCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
+func CreateAWSCloudCredentials(client *rancher.Client, credentials cloudcredentials.CloudCredential) (*v1.SteveAPIObject, error) {
+	secretName := namegenerator.AppendRandomString(providers.AWS)
+	spec := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: cloudcredentials.GeneratedName,
+			Namespace:    namespaces.CattleData,
+			Annotations: map[string]string{
+				"provisioning.cattle.io/driver": providers.AWS,
+				"field.cattle.io/name":          secretName,
+				"field.cattle.io/creatorId":     client.UserID,
+			},
+		},
+		Data: map[string][]byte{
+			"amazonec2credentialConfig-accessKey":     []byte(credentials.AmazonEC2CredentialConfig.AccessKey),
+			"amazonec2credentialConfig-secretKey":     []byte(credentials.AmazonEC2CredentialConfig.SecretKey),
+			"amazonec2credentialConfig-defaultRegion": []byte(credentials.AmazonEC2CredentialConfig.DefaultRegion),
+		},
+		Type: corev1.SecretTypeOpaque,
 	}
 
-	resp := &cloudcredentials.CloudCredential{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.CloudCredentialType, cloudCredential, resp)
+	awsCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+
+	return awsCloudCredentials, nil
 }

--- a/extensions/cloudcredentials/azure/create.go
+++ b/extensions/cloudcredentials/azure/create.go
@@ -2,28 +2,44 @@ package azure
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
-	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/extensions/steve"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const azureCloudCredNameBase = "azureOceanCloudCredential"
-
-// CreateAzureCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
-// an Azure cloud credential, and returns the CloudCredential response
-func CreateAzureCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
-	var azureCredentialConfig cloudcredentials.AzureCredentialConfig
-	config.LoadConfig(cloudcredentials.AzureCredentialConfigurationFileKey, &azureCredentialConfig)
-
-	cloudCredential := cloudcredentials.CloudCredential{
-		Name:                  azureCloudCredNameBase,
-		AzureCredentialConfig: &azureCredentialConfig,
+// CreateAzureCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
+func CreateAzureCloudCredentials(client *rancher.Client, credentials cloudcredentials.CloudCredential) (*v1.SteveAPIObject, error) {
+	secretName := namegenerator.AppendRandomString(providers.Azure)
+	spec := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: cloudcredentials.GeneratedName,
+			Namespace:    namespaces.CattleData,
+			Annotations: map[string]string{
+				"provisioning.cattle.io/driver": providers.Azure,
+				"field.cattle.io/name":          secretName,
+				"field.cattle.io/creatorId":     client.UserID,
+			},
+		},
+		Data: map[string][]byte{
+			"azurecredentialConfig-clientId":       []byte(credentials.AzureCredentialConfig.ClientID),
+			"azurecredentialConfig-clientSecret":   []byte(credentials.AzureCredentialConfig.ClientSecret),
+			"azurecredentialConfig-environment":    []byte(credentials.AzureCredentialConfig.Environment),
+			"azurecredentialConfig-subscriptionId": []byte(credentials.AzureCredentialConfig.SubscriptionID),
+		},
+		Type: corev1.SecretTypeOpaque,
 	}
 
-	resp := &cloudcredentials.CloudCredential{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.CloudCredentialType, cloudCredential, resp)
+	azureCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+
+	return azureCloudCredentials, nil
 }

--- a/extensions/cloudcredentials/cloudcredentials.go
+++ b/extensions/cloudcredentials/cloudcredentials.go
@@ -1,7 +1,15 @@
 package cloudcredentials
 
 import (
+	"fmt"
+
 	"github.com/rancher/norman/types"
+	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/pkg/config"
+)
+
+const (
+	GeneratedName = "cc-"
 )
 
 // CloudCredential is the main struct needed to create a cloud credential depending on the outside cloud service provider
@@ -22,4 +30,70 @@ type CloudCredential struct {
 	GoogleCredentialConfig       *GoogleCredentialConfig        `json:"googlecredentialConfig,omitempty"`
 	VmwareVsphereConfig          *VmwarevsphereCredentialConfig `json:"vmwarevspherecredentialConfig,omitempty"`
 	UUID                         string                         `json:"uuid,omitempty"`
+}
+
+// LoadCloudCredential loads the providers cloudCredentialConfig from the cattle config file
+func LoadCloudCredential(provider string) CloudCredential {
+	var cloudCredential CloudCredential
+	switch {
+
+	case provider == providers.AWS:
+		var awsCredentialConfig AmazonEC2CredentialConfig
+
+		config.LoadConfig(AmazonEC2CredentialConfigurationFileKey, &awsCredentialConfig)
+		cloudCredential.AmazonEC2CredentialConfig = &awsCredentialConfig
+
+		return cloudCredential
+
+	case provider == providers.Azure:
+		var azureCredentialConfig AzureCredentialConfig
+
+		config.LoadConfig(AzureCredentialConfigurationFileKey, &azureCredentialConfig)
+		cloudCredential.AzureCredentialConfig = &azureCredentialConfig
+
+		return cloudCredential
+
+	case provider == providers.DigitalOcean:
+		var digitalOceanCredentialConfig DigitalOceanCredentialConfig
+
+		config.LoadConfig(DigitalOceanCredentialConfigurationFileKey, &digitalOceanCredentialConfig)
+		cloudCredential.DigitalOceanCredentialConfig = &digitalOceanCredentialConfig
+
+		return cloudCredential
+
+	case provider == providers.Linode:
+		var linodeCredentialConfig LinodeCredentialConfig
+
+		config.LoadConfig(LinodeCredentialConfigurationFileKey, &linodeCredentialConfig)
+		cloudCredential.LinodeCredentialConfig = &linodeCredentialConfig
+
+		return cloudCredential
+
+	case provider == providers.Harvester:
+		var harvesterCredentialConfig HarvesterCredentialConfig
+
+		config.LoadConfig(HarvesterCredentialConfigurationFileKey, &harvesterCredentialConfig)
+		cloudCredential.HarvesterCredentialConfig = &harvesterCredentialConfig
+
+		return cloudCredential
+
+	case provider == providers.Vsphere:
+		var vsphereCredentialConfig VmwarevsphereCredentialConfig
+
+		config.LoadConfig(VmwarevsphereCredentialConfigurationFileKey, &vsphereCredentialConfig)
+		cloudCredential.VmwareVsphereConfig = &vsphereCredentialConfig
+
+		return cloudCredential
+
+	case provider == providers.Google:
+		var googleCredentialConfig GoogleCredentialConfig
+
+		config.LoadConfig(GoogleCredentialConfigurationFileKey, &googleCredentialConfig)
+		cloudCredential.GoogleCredentialConfig = &googleCredentialConfig
+
+		return cloudCredential
+
+	default:
+		panic(fmt.Sprintf("Provider:%v not found", provider))
+	}
 }

--- a/extensions/cloudcredentials/digitalocean/create.go
+++ b/extensions/cloudcredentials/digitalocean/create.go
@@ -2,28 +2,41 @@ package digitalocean
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
-	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/extensions/steve"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const digitalOceanCloudCredNameBase = "digitalOceanCloudCredential"
-
-// CreateDigitalOceanCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
-// a Digital Ocean cloud credential, and returns the CloudCredential response
-func CreateDigitalOceanCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
-	var digitalOceanCredentialConfig cloudcredentials.DigitalOceanCredentialConfig
-	config.LoadConfig(cloudcredentials.DigitalOceanCredentialConfigurationFileKey, &digitalOceanCredentialConfig)
-
-	cloudCredential := cloudcredentials.CloudCredential{
-		Name:                         digitalOceanCloudCredNameBase,
-		DigitalOceanCredentialConfig: &digitalOceanCredentialConfig,
+// CreateDigitalOceanCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
+func CreateDigitalOceanCloudCredentials(client *rancher.Client, credentials cloudcredentials.CloudCredential) (*v1.SteveAPIObject, error) {
+	secretName := namegenerator.AppendRandomString(providers.DigitalOcean)
+	spec := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: cloudcredentials.GeneratedName,
+			Namespace:    namespaces.CattleData,
+			Annotations: map[string]string{
+				"provisioning.cattle.io/driver": providers.DigitalOcean,
+				"field.cattle.io/name":          secretName,
+				"field.cattle.io/creatorId":     client.UserID,
+			},
+		},
+		Data: map[string][]byte{
+			"digitaloceancredentialConfig-accessToken": []byte(credentials.DigitalOceanCredentialConfig.AccessToken),
+		},
+		Type: corev1.SecretTypeOpaque,
 	}
 
-	resp := &cloudcredentials.CloudCredential{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.CloudCredentialType, cloudCredential, resp)
+	digitalOceanCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+
+	return digitalOceanCloudCredentials, nil
 }

--- a/extensions/cloudcredentials/harvester/create.go
+++ b/extensions/cloudcredentials/harvester/create.go
@@ -2,28 +2,43 @@ package harvester
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
-	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/extensions/steve"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const harvesterCloudCredNameBase = "harvesterCloudCredential"
-
-// CreateHarvesterCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
-// a harvester cloud credential, and returns the CloudCredential response
-func CreateHarvesterCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
-	var harvesterCredentialConfig cloudcredentials.HarvesterCredentialConfig
-	config.LoadConfig(cloudcredentials.HarvesterCredentialConfigurationFileKey, &harvesterCredentialConfig)
-
-	cloudCredential := cloudcredentials.CloudCredential{
-		Name:                      harvesterCloudCredNameBase,
-		HarvesterCredentialConfig: &harvesterCredentialConfig,
+// CreateHarvesterCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
+func CreateHarvesterCloudCredentials(client *rancher.Client, credentials cloudcredentials.CloudCredential) (*v1.SteveAPIObject, error) {
+	secretName := namegenerator.AppendRandomString(providers.Harvester)
+	spec := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: cloudcredentials.GeneratedName,
+			Namespace:    namespaces.CattleData,
+			Annotations: map[string]string{
+				"field.cattle.io/name":          secretName,
+				"provisioning.cattle.io/driver": providers.Harvester,
+				"field.cattle.io/creatorId":     client.UserID,
+			},
+		},
+		Data: map[string][]byte{
+			"harvestercredentialConfig-clusterId":         []byte(credentials.HarvesterCredentialConfig.ClusterID),
+			"harvestercredentialConfig-clusterType":       []byte(credentials.HarvesterCredentialConfig.ClusterType),
+			"harvestercredentialConfig-kubeconfigContent": []byte(credentials.HarvesterCredentialConfig.KubeconfigContent),
+		},
+		Type: corev1.SecretTypeOpaque,
 	}
 
-	resp := &cloudcredentials.CloudCredential{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.CloudCredentialType, cloudCredential, resp)
+	harvesterCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+
+	return harvesterCloudCredentials, nil
 }

--- a/extensions/cloudcredentials/linode/create.go
+++ b/extensions/cloudcredentials/linode/create.go
@@ -2,28 +2,40 @@ package linode
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
-	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/extensions/steve"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const linodeCloudCredNameBase = "linodeCloudCredential"
-
-// CreateLinodeCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
-// a Linode cloud credential, and returns the CloudCredential response
-func CreateLinodeCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
-	var linodeCredentialConfig cloudcredentials.LinodeCredentialConfig
-	config.LoadConfig(cloudcredentials.LinodeCredentialConfigurationFileKey, &linodeCredentialConfig)
-
-	cloudCredential := cloudcredentials.CloudCredential{
-		Name:                   linodeCloudCredNameBase,
-		LinodeCredentialConfig: &linodeCredentialConfig,
+// CreateLinodeCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
+func CreateLinodeCloudCredentials(client *rancher.Client, credentials cloudcredentials.CloudCredential) (*v1.SteveAPIObject, error) {
+	secretName := namegenerator.AppendRandomString(providers.Linode)
+	spec := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: cloudcredentials.GeneratedName,
+			Namespace:    namespaces.CattleData,
+			Annotations: map[string]string{
+				"field.cattle.io/name":      secretName,
+				"field.cattle.io/creatorId": client.UserID,
+			},
+		},
+		Data: map[string][]byte{
+			"linodecredentialConfig-token": []byte(credentials.LinodeCredentialConfig.Token),
+		},
+		Type: corev1.SecretTypeOpaque,
 	}
 
-	resp := &cloudcredentials.CloudCredential{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.CloudCredentialType, cloudCredential, resp)
+	linodeCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+
+	return linodeCloudCredentials, nil
 }

--- a/extensions/cloudcredentials/vsphere/create.go
+++ b/extensions/cloudcredentials/vsphere/create.go
@@ -2,30 +2,49 @@ package vsphere
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const vmwarevsphereCloudCredNameBase = "vmwarevsphereCloudCredential"
+const (
+	vsphereProvider     = "vsphere"
+	credentialNamespace = "cattle-global-data"
+)
 
-// CreateVsphereCloudCredentials is a helper function that takes the rancher Client as a parameter and creates
-// an AWS cloud credential, and returns the CloudCredential response
-func CreateVsphereCloudCredentials(rancherClient *rancher.Client) (*cloudcredentials.CloudCredential, error) {
-	var vmwarevsphereCredentialConfig cloudcredentials.VmwarevsphereCredentialConfig
-	config.LoadConfig(cloudcredentials.VmwarevsphereCredentialConfigurationFileKey, &vmwarevsphereCredentialConfig)
-
-	cloudCredential := cloudcredentials.CloudCredential{
-		Name:                vmwarevsphereCloudCredNameBase,
-		VmwareVsphereConfig: &vmwarevsphereCredentialConfig,
+// CreateVsphereCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
+func CreateVsphereCloudCredentials(client *rancher.Client, credentials cloudcredentials.CloudCredential) (*v1.SteveAPIObject, error) {
+	secretName := namegenerator.AppendRandomString(vsphereProvider)
+	spec := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: cloudcredentials.GeneratedName,
+			Namespace:    credentialNamespace,
+			Annotations: map[string]string{
+				"field.cattle.io/name":      secretName,
+				"field.cattle.io/creatorId": client.UserID,
+			},
+		},
+		Data: map[string][]byte{
+			"vmwarevspherecredentialConfig-password":    []byte(credentials.VmwareVsphereConfig.Password),
+			"vmwarevspherecredentialConfig-username":    []byte(credentials.VmwareVsphereConfig.Username),
+			"vmwarevspherecredentialConfig-vcenter":     []byte(credentials.VmwareVsphereConfig.Vcenter),
+			"vmwarevspherecredentialConfig-vcenterPort": []byte(credentials.VmwareVsphereConfig.VcenterPort),
+		},
+		Type: corev1.SecretTypeOpaque,
 	}
 
-	resp := &cloudcredentials.CloudCredential{}
-	err := rancherClient.Management.APIBaseClient.Ops.DoCreate(management.CloudCredentialType, cloudCredential, resp)
+	vSphereCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+
+	return vSphereCloudCredentials, nil
 }
 
 // GetVspherePassword is a helper to get the password from the cloud credential object as a string

--- a/extensions/defaults/namespaces/namespaces.go
+++ b/extensions/defaults/namespaces/namespaces.go
@@ -1,0 +1,5 @@
+package namespaces
+
+const (
+	CattleData = "cattle-global-data"
+)

--- a/extensions/defaults/providers/providers.go
+++ b/extensions/defaults/providers/providers.go
@@ -1,0 +1,11 @@
+package providers
+
+const (
+	AWS          = "aws"
+	Azure        = "azure"
+	DigitalOcean = "do"
+	Harvester    = "harvester"
+	Linode       = "linode"
+	Google       = "google"
+	Vsphere      = "vsphere"
+)


### PR DESCRIPTION
Convert V3-->V1 objects and also move the loadConfig call outside of the cloud credentials create as it is bad practice to:
1. Hardcode a load config in functional logic that gets reused (reduces reusability)
2. Combine crud operations. (in this case get and create)