### PR TITLE
Add support for setting k8s version in EKS NodeGroup

### DIFF
--- a/extensions/clusters/eks/eks_cluster_config.go
+++ b/extensions/clusters/eks/eks_cluster_config.go
@@ -48,6 +48,7 @@ type NodeGroupConfig struct {
 	Subnets              []string              `json:"subnets" yaml:"subnets"`
 	Tags                 map[string]string     `json:"tags" yaml:"tags"`
 	UserData             *string               `json:"userData,omitempty" yaml:"userData,omitempty"`
+	Version              *string               `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 // LaunchTemplateConfig is the configuration need for a node group launch template
@@ -67,6 +68,12 @@ func nodeGroupsConstructor(nodeGroupsConfig *[]NodeGroupConfig, kubernetesVersio
 				Name:    nodeGroupConfig.LaunchTemplateConfig.Name,
 				Version: nodeGroupConfig.LaunchTemplateConfig.Version,
 			}
+		}
+		var version *string
+		if nodeGroupConfig.Version != nil {
+			version = nodeGroupConfig.Version
+		} else {
+			version = &kubernetesVersion
 		}
 		nodeGroup := management.NodeGroup{
 			Arm:                  nodeGroupConfig.Arm,
@@ -88,7 +95,7 @@ func nodeGroupsConstructor(nodeGroupsConfig *[]NodeGroupConfig, kubernetesVersio
 			Subnets:              &nodeGroupConfig.Subnets,
 			Tags:                 &nodeGroupConfig.Tags,
 			UserData:             nodeGroupConfig.UserData,
-			Version:              &kubernetesVersion,
+			Version:              version,
 		}
 		nodeGroups = append(nodeGroups, nodeGroup)
 	}


### PR DESCRIPTION
Adds support for a different k8s version on EKS nodegroup than used on control-plane.

This allows to define an invalid EKS cluster under rancher which is needed for negative testing of Hosted Providers operators.

![image](https://github.com/user-attachments/assets/31cf98aa-271e-41ff-b1d5-4f68b1f92269)

If the nodegroup k8s version is not defined it will use the same version as for control-plane so it should be backward compatible.
