### PR TITLE
[2.8] Add a Quarantined Flag to the Environment Flags

### DIFF
--- a/pkg/environmentflag/environmentflags.go
+++ b/pkg/environmentflag/environmentflags.go
@@ -17,5 +17,6 @@ const (
 	InstallRancher
 	Long
 	Short
+	Quarantined
 	environmentFlagLastItem // This is used to determine the number of items in the enum
 )

--- a/pkg/environmentflag/zz_environmentflags.go
+++ b/pkg/environmentflag/zz_environmentflags.go
@@ -17,12 +17,13 @@ func _() {
 	_ = x[InstallRancher-6]
 	_ = x[Long-7]
 	_ = x[Short-8]
-	_ = x[environmentFlagLastItem-9]
+	_ = x[Quarantined-9]
+	_ = x[environmentFlagLastItem-10]
 }
 
-const _EnvironmentFlag_name = "KubernetesUpgradeAllClustersWorkloadUpgradeAllClustersUpdateClusterNameGatekeeperAllowedNamespacesUpgradeAllClustersUseExistingRegistriesInstallRancherLongShortThis is used to determine the number of items in the enum"
+const _EnvironmentFlag_name = "KubernetesUpgradeAllClustersWorkloadUpgradeAllClustersUpdateClusterNameGatekeeperAllowedNamespacesUpgradeAllClustersUseExistingRegistriesInstallRancherLongShortQuarantinedThis is used to determine the number of items in the enum"
 
-var _EnvironmentFlag_index = [...]uint8{0, 28, 54, 71, 98, 116, 137, 151, 155, 160, 217}
+var _EnvironmentFlag_index = [...]uint8{0, 28, 54, 71, 98, 116, 137, 151, 155, 160, 171, 228}
 
 func (i EnvironmentFlag) String() string {
 	if i < 0 || i >= EnvironmentFlag(len(_EnvironmentFlag_index)-1) {


### PR DESCRIPTION
## Issue:  rancher/qa-tasks/issues/1484 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Currently to skip a test, `t.Skip `is used. To run a test, these skips in the code need to be changed/updated.
 
## Solution
<!-- Describe what you changed or added to fix the issue. Relate your changes back to the original issue and explain why this addresses the issue. -->
Adds a quarantined flag to the environment flags, and method to the rancher/rancher tests.
 
## Testing
<!-- Note: Confirm the changes are not creating any regressions in Shepherd and existing tests -->
This flag will be mainly used in the integration tests. So testing will be in r/r side of this PR.
