### PR TITLE
[main] Add config variables for registry secret credentials

### DIFF
--- a/clients/rancher/config.go
+++ b/clients/rancher/config.go
@@ -5,14 +5,17 @@ const ConfigurationFileKey = "rancher"
 
 // Config is configuration need to test against a rancher instance
 type Config struct {
-	Host          string `yaml:"host" json:"host"`
-	AdminToken    string `yaml:"adminToken" json:"adminToken"`
-	AdminPassword string `yaml:"adminPassword" json:"adminPassword"`
-	Insecure      *bool  `yaml:"insecure" json:"insecure" default:"true"`
-	Cleanup       *bool  `yaml:"cleanup" json:"cleanup" default:"true"`
-	CAFile        string `yaml:"caFile" json:"caFile" default:""`
-	CACerts       string `yaml:"caCerts" json:"caCerts" default:""`
-	ClusterName   string `yaml:"clusterName" json:"clusterName" default:""`
-	ShellImage    string `yaml:"shellImage" json:"shellImage" default:""`
-	RancherCLI    bool   `yaml:"rancherCLI" json:"rancherCLI" default:"false"`
+	Host             string `yaml:"host" json:"host"`
+	AdminToken       string `yaml:"adminToken" json:"adminToken"`
+	AdminPassword    string `yaml:"adminPassword" json:"adminPassword"`
+	Insecure         *bool  `yaml:"insecure" json:"insecure" default:"true"`
+	Cleanup          *bool  `yaml:"cleanup" json:"cleanup" default:"true"`
+	CAFile           string `yaml:"caFile" json:"caFile" default:""`
+	CACerts          string `yaml:"caCerts" json:"caCerts" default:""`
+	ClusterName      string `yaml:"clusterName" json:"clusterName" default:""`
+	ShellImage       string `yaml:"shellImage" json:"shellImage" default:""`
+	RancherCLI       bool   `yaml:"rancherCLI" json:"rancherCLI" default:"false"`
+	Registry         string `yaml:"registry" json:"registry" default:""`
+	RegistryUsername string `yaml:"registryUsername" json:"registryUsername" default:""`
+	RegistryPassword string `yaml:"registryPassword" json:"registryPassword" default:""`
 }


### PR DESCRIPTION
As part of the migration task from Python to Go, we are migrating some of the RBAC registry secret tests. For more details, refer: https://github.com/rancher/qa-tasks/issues/1348 

The RBAC registry secret tests require registry credentials. In this PR, new variables have been added to the Rancher configuration to allow users to provide these credentials.

Here are the backport PRs:
- 2.8: https://github.com/rancher/shepherd/pull/345
- 2.9: https://github.com/rancher/shepherd/pull/346
- 2.10: https://github.com/rancher/shepherd/pull/347