### PR TITLE
[2.9] Fix corral file wait and update the debugging option

### DIFF
--- a/clients/corral/corral.go
+++ b/clients/corral/corral.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	debugFlag               = "--trace"
+	debugFlag               = "--debug"
 	skipCleanupFlag         = "--skip-cleanup"
 	corralPrivateSSHKey     = "corral_private_key"
 	corralPublicSSHKey      = "corral_public_key"
@@ -152,13 +152,21 @@ func waitForCorralConfig(corralName string) error {
 	corralOSPath := homeDir + "/.corral/corrals/" + corralName + "/corral.yaml"
 
 	return wait.ExponentialBackoff(backoff, func() (finished bool, err error) {
-		_, err = os.Stat(corralOSPath)
+		fileStat, err := os.Stat(corralOSPath)
 		if err != nil {
+			return false, nil
+		}
+
+		if fileStat == nil {
 			return false, nil
 		}
 
 		fileContents, err := os.ReadFile(corralOSPath)
 		if err != nil {
+			return false, nil
+		}
+
+		if fileContents == nil {
 			return false, nil
 		}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/qa-tasks/issues/1601 & https://github.com/rancher/qa-tasks/issues/1602 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Corral file wait should account for the nil return value from `os.Stat`, which is the state if the file doesn't exist. Currently, the separated command solution makes recurring runs fail because it doesn't wait for the file.
 
## Solution
<!-- Describe what you changed or added to fix the issue. Relate your changes back to the original issue and explain why this addresses the issue. -->

Account nil return value from `os.Stat`, update to debug flag which gives more output for corral creation.

