### PR TITLE
Add harvester Client

### DIFF
--- a/clients/harvester/client.go
+++ b/clients/harvester/client.go
@@ -1,0 +1,101 @@
+package harvester
+
+import (
+	"fmt"
+
+	frameworkDynamic "github.com/rancher/shepherd/clients/dynamic"
+	"github.com/rancher/shepherd/clients/rancher/catalog"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+
+	"github.com/rancher/shepherd/pkg/clientbase"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/environmentflag"
+	"github.com/rancher/shepherd/pkg/session"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// Client is the main harvester Client object that gives an end user access to the Provisioning and Catalog
+// clients in order to create resources on harvester
+type Client struct {
+	// Client used to access Steve v1 API resources
+	Steve *v1.Client
+	// Client used to access catalog.cattle.io v1 API resources (apps, charts, etc.)
+	Catalog *catalog.Client
+	// Config used to test against a harvester instance
+	HarvesterConfig *Config
+	// Session is the session object used by the client to track all the resources being created by the client.
+	Session *session.Session
+
+	restConfig *rest.Config
+}
+
+// NewClient is the constructor to the initializing a harvester Client. It takes a bearer token and session.Session. If bearer token is not provided,
+// the bearer token provided in the configuration file is used.
+func NewClient(bearerToken string, session *session.Session) (*Client, error) {
+	harvesterConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, harvesterConfig)
+
+	environmentFlags := environmentflag.NewEnvironmentFlags()
+	environmentflag.LoadEnvironmentFlags(environmentflag.ConfigurationFileKey, environmentFlags)
+
+	if bearerToken == "" {
+		bearerToken = harvesterConfig.AdminToken
+	}
+
+	c := &Client{
+		HarvesterConfig: harvesterConfig,
+	}
+
+	session.CleanupEnabled = *harvesterConfig.Cleanup
+
+	var err error
+	restConfig := newRestConfig(bearerToken, harvesterConfig)
+	c.restConfig = restConfig
+	c.Session = session
+
+	c.Steve, err = v1.NewClient(clientOptsV1(restConfig, c.HarvesterConfig))
+	if err != nil {
+		return nil, err
+	}
+
+	c.Steve.Ops.Session = session
+
+	catalogClient, err := catalog.NewForConfig(restConfig, session)
+	if err != nil {
+		return nil, err
+	}
+
+	c.Catalog = catalogClient
+
+	return c, nil
+}
+
+// newRestConfig is a constructor that sets ups rest.Config the configuration used by the Provisioning client.
+func newRestConfig(bearerToken string, harvesterConfig *Config) *rest.Config {
+	return &rest.Config{
+		Host:        harvesterConfig.Host,
+		BearerToken: bearerToken,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: *harvesterConfig.Insecure,
+		},
+	}
+}
+
+// clientOptsV1 is a constructor that sets ups clientbase.ClientOpts the configuration used by the v1 harvester clients.
+func clientOptsV1(restConfig *rest.Config, harvesterConfig *Config) *clientbase.ClientOpts {
+	return &clientbase.ClientOpts{
+		URL:      fmt.Sprintf("https://%s/v1", harvesterConfig.Host),
+		TokenKey: restConfig.BearerToken,
+		Insecure: restConfig.Insecure,
+	}
+}
+
+// GetHarvesterDynamicClient is a helper function that instantiates a dynamic client to communicate with the harvester host.
+func (c *Client) GetHarvesterDynamicClient() (dynamic.Interface, error) {
+	dynamic, err := frameworkDynamic.NewForConfig(c.Session, c.restConfig)
+	if err != nil {
+		return nil, err
+	}
+	return dynamic, nil
+}

--- a/clients/harvester/config.go
+++ b/clients/harvester/config.go
@@ -1,0 +1,13 @@
+package harvester
+
+// The json/yaml config key for the harvester config
+const ConfigurationFileKey = "harvester"
+
+// Config is configuration need to test against a harvester instance
+type Config struct {
+	Host          string `yaml:"host" json:"host"`
+	AdminToken    string `yaml:"adminToken" json:"adminToken"`
+	AdminPassword string `yaml:"adminPassword" json:"adminPassword"`
+	Insecure      *bool  `yaml:"insecure" json:"insecure" default:"true"`
+	Cleanup       *bool  `yaml:"cleanup" json:"cleanup" default:"true"`
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/qa-tasks/issues/468
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
currently, we don't have a way to write automation for harvester using the framework. 
 
## Solution
<!-- Describe what you changed or added to fix the issue. Relate your changes back to the original issue and explain why this addresses the issue. -->
harvester's API is based on rancher's steve. In this PR I've introduced a harvester client that wraps steve and catalog clients, introduced a new harvesterConfig, similar to how rancherClient is setup. 

We played around with wrapping Steve's API/client directly, but since harvester will need the catalog client as well, giving harvester its own client makes more sense in the long run + to support any use cases their team may have. 

Also played around with simplifying the copy-paste logic between rancher and now harvester clients. But this may make more sense to do if we have to introduce another client that uses most of rancher's API which I don't know of a product that would need it tbh. If this approach were taken, the code would be refactored instead of net-new, risking stuff breaking. 
 
## Testing
<!-- Note: Confirm the changes are not creating any regressions in Shepherd and existing tests -->
see linked rancher PR; we are now able to use harvester's API and import an existing harvester cluster into an existing rancher setup. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

this is a new client, so no risk of regression. 
