### PR TITLE
Create steve helpers for OS checks

### DIFF
--- a/extensions/cloudcredentials/aws/create.go
+++ b/extensions/cloudcredentials/aws/create.go
@@ -7,11 +7,16 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/shepherd/pkg/namegenerator"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	localCluster = "local"
 )
 
 // CreateAWSCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
@@ -35,7 +40,7 @@ func CreateAWSCloudCredentials(client *rancher.Client, credentials cloudcredenti
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	awsCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
+	awsCloudCredentials, err := steve.CreateAndWaitForResource(client, namespaces.FleetLocal+"/"+localCluster, stevetypes.Secret, spec, stevestates.Active, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/cloudcredentials/aws_config.go
+++ b/extensions/cloudcredentials/aws_config.go
@@ -7,5 +7,5 @@ const AmazonEC2CredentialConfigurationFileKey = "awsCredentials"
 type AmazonEC2CredentialConfig struct {
 	AccessKey     string `json:"accessKey" yaml:"accessKey"`
 	SecretKey     string `json:"secretKey" yaml:"secretKey"`
-	DefaultRegion string `json:"defaultRegion,omitempty" yaml:"defaultRegion"`
+	DefaultRegion string `json:"defaultRegion,omitempty" yaml:"defaultRegion,omitempty"`
 }

--- a/extensions/cloudcredentials/azure/create.go
+++ b/extensions/cloudcredentials/azure/create.go
@@ -7,11 +7,16 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/shepherd/pkg/namegenerator"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	localCluster = "local"
 )
 
 // CreateAzureCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
@@ -36,7 +41,7 @@ func CreateAzureCloudCredentials(client *rancher.Client, credentials cloudcreden
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	azureCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
+	azureCloudCredentials, err := steve.CreateAndWaitForResource(client, namespaces.FleetLocal+"/"+localCluster, stevetypes.Secret, spec, stevestates.Active, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/cloudcredentials/digitalocean/create.go
+++ b/extensions/cloudcredentials/digitalocean/create.go
@@ -7,11 +7,16 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/shepherd/pkg/namegenerator"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	localCluster = "local"
 )
 
 // CreateDigitalOceanCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
@@ -33,7 +38,7 @@ func CreateDigitalOceanCloudCredentials(client *rancher.Client, credentials clou
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	digitalOceanCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
+	digitalOceanCloudCredentials, err := steve.CreateAndWaitForResource(client, namespaces.FleetLocal+"/"+localCluster, stevetypes.Secret, spec, stevestates.Active, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/cloudcredentials/google/create.go
+++ b/extensions/cloudcredentials/google/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/shepherd/pkg/namegenerator"
@@ -16,6 +17,7 @@ import (
 
 const (
 	googleProvider = "gcp"
+	localCluster   = "local"
 )
 
 // CreateGoogleCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
@@ -37,7 +39,7 @@ func CreateGoogleCloudCredentials(client *rancher.Client, credentials cloudcrede
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	googleCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
+	googleCloudCredentials, err := steve.CreateAndWaitForResource(client, namespaces.FleetLocal+"/"+localCluster, stevetypes.Secret, spec, stevestates.Active, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/cloudcredentials/harvester/create.go
+++ b/extensions/cloudcredentials/harvester/create.go
@@ -7,11 +7,16 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/shepherd/pkg/namegenerator"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	localCluster = "local"
 )
 
 // CreateHarvesterCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
@@ -35,7 +40,7 @@ func CreateHarvesterCloudCredentials(client *rancher.Client, credentials cloudcr
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	harvesterCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
+	harvesterCloudCredentials, err := steve.CreateAndWaitForResource(client, namespaces.FleetLocal+"/"+localCluster, stevetypes.Secret, spec, stevestates.Active, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/cloudcredentials/linode/create.go
+++ b/extensions/cloudcredentials/linode/create.go
@@ -7,11 +7,16 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/providers"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/shepherd/pkg/namegenerator"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	localCluster = "local"
 )
 
 // CreateLinodeCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
@@ -32,7 +37,7 @@ func CreateLinodeCloudCredentials(client *rancher.Client, credentials cloudcrede
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	linodeCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
+	linodeCloudCredentials, err := steve.CreateAndWaitForResource(client, namespaces.FleetLocal+"/"+localCluster, stevetypes.Secret, spec, stevestates.Active, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/cloudcredentials/vsphere/create.go
+++ b/extensions/cloudcredentials/vsphere/create.go
@@ -5,6 +5,8 @@ import (
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/shepherd/pkg/config"
@@ -14,8 +16,8 @@ import (
 )
 
 const (
-	vsphereProvider     = "vsphere"
-	credentialNamespace = "cattle-global-data"
+	vsphereProvider = "vsphere"
+	localCluster    = "local"
 )
 
 // CreateVsphereCloudCredentials is a helper function that creates V1 cloud credentials and waits for them to become active.
@@ -24,7 +26,7 @@ func CreateVsphereCloudCredentials(client *rancher.Client, credentials cloudcred
 	spec := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: cloudcredentials.GeneratedName,
-			Namespace:    credentialNamespace,
+			Namespace:    namespaces.CattleData,
 			Annotations: map[string]string{
 				"field.cattle.io/name":      secretName,
 				"field.cattle.io/creatorId": client.UserID,
@@ -39,7 +41,7 @@ func CreateVsphereCloudCredentials(client *rancher.Client, credentials cloudcred
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	vSphereCloudCredentials, err := steve.CreateAndWaitForResource(client, stevetypes.Secret, spec, true, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
+	vSphereCloudCredentials, err := steve.CreateAndWaitForResource(client, namespaces.FleetLocal+"/"+localCluster, stevetypes.Secret, spec, stevestates.Active, defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/defaults/namespaces/namespaces.go
+++ b/extensions/defaults/namespaces/namespaces.go
@@ -1,5 +1,7 @@
 package namespaces
 
 const (
-	CattleData = "cattle-global-data"
+	CattleData   = "cattle-global-data"
+	FleetLocal   = "fleet-local"
+	FleetDefault = "fleet-default"
 )

--- a/extensions/defaults/stevestates/stevestates.go
+++ b/extensions/defaults/stevestates/stevestates.go
@@ -1,0 +1,9 @@
+package stevestates
+
+const (
+	Active      = "active"
+	NotActive   = "running"
+	Reconciling = "reconciling"
+	Error       = "error"
+	Updating    = "updating"
+)

--- a/extensions/defaults/stevetypes/stevetypes.go
+++ b/extensions/defaults/stevetypes/stevetypes.go
@@ -5,6 +5,8 @@ const (
 	EtcdSnapshot = "rke.cattle.io.etcdsnapshot"
 	FleetCluster = "fleet.cattle.io.cluster"
 	ClusterRepo  = "catalog.cattle.io.clusterrepo"
+	Machine      = "cluster.x-k8s.io.machine"
 	Apps         = "catalog.cattle.io.apps"
 	Secret       = "secret"
+	Node         = "node"
 )

--- a/extensions/steve/steve.go
+++ b/extensions/steve/steve.go
@@ -5,24 +5,27 @@ import (
 	"strings"
 	"time"
 
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/sirupsen/logrus"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
-	notFound = "not found"
-	active   = "active"
+	notFound     = "not found"
+	localCluster = "local"
 )
 
-// WaitForSteveResourceDeletion accepts a client, steve resource type, and resource ID, then waits for a steve resource to be deleted
-func WaitForSteveResourceDeletion(client *rancher.Client, interval, timeout time.Duration, steveResourceType, steveID string) error {
+// WaitForResourceDeletion waits for a given steve object to be deleted.
+func WaitForResourceDeletion(client *v1.Client, v1Resource *v1.SteveAPIObject, interval, timeout time.Duration) error {
 	err := kwait.PollUntilContextTimeout(context.TODO(), interval, timeout, true, func(ctx context.Context) (done bool, err error) {
-		_, err = client.Steve.SteveType(steveResourceType).ByID(steveID)
+		_, err = client.SteveType(v1Resource.Type).ByID(v1Resource.ID)
 		if err != nil {
 			if strings.Contains(err.Error(), notFound) {
-				logrus.Info("Resource was successfully removed!")
+				logrus.Infof("%s(%s) is deleted", v1Resource.Kind, v1Resource.Name)
 				return true, nil
 			} else {
 				return false, err
@@ -39,21 +42,17 @@ func WaitForSteveResourceDeletion(client *rancher.Client, interval, timeout time
 	return nil
 }
 
-// WaitForSteveResourceCreation waits for a given steve object to be created/come up active.
-func WaitForSteveResourceCreation(client *rancher.Client, v1Resource *v1.SteveAPIObject, interval, timeout time.Duration) error {
+// WaitForResourceState waits for a given steve object to be reach a desired state.
+func WaitForResourceState(client *v1.Client, v1Resource *v1.SteveAPIObject, desiredState string, interval, timeout time.Duration) error {
+	logrus.Infof("Waiting for %s(%s) to reach a %s state", v1Resource.Kind, v1Resource.Name, desiredState)
 	err := kwait.PollUntilContextTimeout(context.TODO(), interval, timeout, true, func(ctx context.Context) (done bool, err error) {
-		client, err = client.ReLogin()
+		clusterResp, err := client.SteveType(v1Resource.Type).ByID(v1Resource.ID)
 		if err != nil {
 			return false, err
 		}
 
-		clusterResp, err := client.Steve.SteveType(v1Resource.Type).ByID(v1Resource.ID)
-		if err != nil {
-			return false, err
-		}
-
-		if clusterResp.ObjectMeta.State.Name == active {
-			logrus.Infof("%s(%s) is active", v1Resource.Kind, v1Resource.Name)
+		if clusterResp.ObjectMeta.State.Name == desiredState {
+			logrus.Infof("%s(%s) is %s", v1Resource.Kind, v1Resource.Name, desiredState)
 			return true, nil
 		}
 
@@ -63,20 +62,55 @@ func WaitForSteveResourceCreation(client *rancher.Client, v1Resource *v1.SteveAP
 	return err
 }
 
-// CreateResource creates a steve resource and polls the resulting object until it comes up active.
-func CreateAndWaitForResource(client *rancher.Client, v1ResourceType string, v1Resource any, poll bool, interval, timeout time.Duration) (*v1.SteveAPIObject, error) {
-	resource, err := client.Steve.SteveType(v1ResourceType).Create(v1Resource)
+// CreateAndWaitForResource creates a steve resource and polls the resulting object until it is in the provided state.
+func CreateAndWaitForResource(client *rancher.Client, clusterID, v1ResourceType string, v1Resource any, desiredState string, interval, timeout time.Duration) (*v1.SteveAPIObject, error) {
+	steveClient, err := GetClusterClient(client, clusterID)
 	if err != nil {
 		return nil, err
 	}
+
+	resource, err := steveClient.SteveType(v1ResourceType).Create(v1Resource)
+	if err != nil {
+		return nil, err
+	}
+
 	logrus.Infof("Creating %s(%s)", resource.Kind, resource.Name)
 
-	if poll {
-		err := WaitForSteveResourceCreation(client, resource, interval, timeout)
+	if interval != 0 && timeout != 0 {
+		err := WaitForResourceState(steveClient, resource, desiredState, interval, timeout)
 		if err != nil {
 			return resource, err
 		}
 	}
 
 	return resource, nil
+}
+
+// GetClusterClient fetches the the client of a downstream cluster.
+func GetClusterClient(client *rancher.Client, clusterID string) (*v1.Client, error) {
+	var clusterClient *v1.Client
+	var err error
+
+	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err := adminClient.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	status := &provv1.ClusterStatus{}
+	err = steveV1.ConvertToK8sType(cluster.Status, status)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterClient, err = adminClient.Steve.ProxyDownstream(status.ClusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	return clusterClient, err
 }


### PR DESCRIPTION
Related Rancher PR: https://github.com/rancher/tests/pull/37
Description: 
1. Created a new func for accessing the ec2 client which will be used for accessing ami data for the OS checks
2. Made some changes to the steve.go to fix a bug and to allow it to be more generic so it can be used in a node reboot helper. (this includes updates to all functions that utilze this)
3. Add a few constants for 1. and 2.