### PR TITLE
Undo changes to project namespace

### DIFF
--- a/extensions/users/users.go
+++ b/extensions/users/users.go
@@ -87,9 +87,6 @@ func AddProjectMember(rancherClient *rancher.Client, project *management.Project
 
 	projectID := strings.Split(project.ID, ":")
 	namespace := string(projectID[0])
-	if project.BackingNamespace != "" {
-		namespace = project.BackingNamespace
-	}
 	name := string(projectID[1])
 
 	adminClient, err := rancher.NewClient(rancherClient.RancherConfig.AdminToken, rancherClient.Session)


### PR DESCRIPTION
I misdiagnosed the cause of the integration test failures in https://github.com/rancher/rancher/pull/49797. I thought that the issue was the namespace being watched, but it was actually the Condition not being satisfied. Reverting.