### PR TITLE
multiple rancher client support

### DIFF
--- a/clients/rancher/config.go
+++ b/clients/rancher/config.go
@@ -3,8 +3,8 @@ package rancher
 // The json/yaml config key for the rancher config
 const ConfigurationFileKey = "rancher"
 
-// Config is configuration need to test against a rancher instance
-type Config struct {
+// ConfigCommon contains the common fields for both Config and InstanceConfig
+type ConfigCommon struct {
 	Host          string `yaml:"host" json:"host"`
 	AdminToken    string `yaml:"adminToken" json:"adminToken"`
 	AdminPassword string `yaml:"adminPassword" json:"adminPassword"`
@@ -15,4 +15,15 @@ type Config struct {
 	ClusterName   string `yaml:"clusterName" json:"clusterName" default:""`
 	ShellImage    string `yaml:"shellImage" json:"shellImage" default:""`
 	RancherCLI    bool   `yaml:"rancherCLI" json:"rancherCLI" default:"false"`
+}
+
+// Config is the configuration needed to test it against a rancher instance
+type Config struct {
+	ConfigCommon     `yaml:",inline"`
+	RancherInstances []InstanceConfig `yaml:"rancherInstances" json:"rancherInstances" default:"[]"`
+}
+
+// InstanceConfig represents configuration for additional Rancher instances
+type InstanceConfig struct {
+	ConfigCommon `yaml:",inline"`
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
The Rancher client only supports a single instance connection. We need to test scenarios with both hosted and tenant Rancher servers in the same test session. Manual testing for global role propagation between instances takes too much time and is error-prone.

## Solution
Added multi-instance support using the `NewClientForConfig` method from PR https://github.com/rancher/shepherd/pull/296:
1. Added `RancherInstances` field to store additional clients
2. Created `RancherClients()` method that uses `NewClientForConfig` to initialize connections to other Rancher instances from config
3. Extended config to support multiple instances via `RancherInstances` array
4. Created `InstanceConfig` struct for additional instance configs
5. Moved common config fields to `ConfigCommon` struct to avoid duplication

Now we can run automated tests that need both hosted and tenant Rancher servers.

## Testing
### Regressions Considerations
- **Config compatibility**: Existing configs still work. `ConfigCommon` embeds inline, keeping the structure intact
- **Nil safety**: `RancherClients()` returns empty slice if no extra instances configured
- **Error handling**: Fails fast if any instance fails to initialize

**Regression risk**: Low - changes are additive, existing single-instance behavior unchanged