### PR TITLE
Add ForConfig functions for functions in Rancher and Harvester Clients

### DIFF
--- a/clients/harvester/client.go
+++ b/clients/harvester/client.go
@@ -62,18 +62,17 @@ func NewClientForConfig(bearerToken string, harvesterConfig *Config, session *se
 	}
 
 	var err error
-	restConfig := newRestConfig(bearerToken, c.HarvesterConfig)
-	c.restConfig = restConfig
+	c.restConfig = newRestConfig(bearerToken, c.HarvesterConfig)
 	c.Session = session
 
-	c.Steve, err = v1.NewClient(clientOptsV1(restConfig, c.HarvesterConfig))
+	c.Steve, err = v1.NewClient(clientOptsV1(c.restConfig, c.HarvesterConfig))
 	if err != nil {
 		return nil, err
 	}
 
 	c.Steve.Ops.Session = session
 
-	catalogClient, err := catalog.NewForConfig(restConfig, session)
+	catalogClient, err := catalog.NewForConfig(c.restConfig, session)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +82,7 @@ func NewClientForConfig(bearerToken string, harvesterConfig *Config, session *se
 	return c, nil
 }
 
-// newRestConfig is a constructor that sets ups rest.Config the configuration used by the Provisioning client.
+// newRestConfig is a constructor that sets up a rest.Config the configuration used by the Provisioning client.
 func newRestConfig(bearerToken string, harvesterConfig *Config) *rest.Config {
 	return &rest.Config{
 		Host:        harvesterConfig.Host,
@@ -94,7 +93,7 @@ func newRestConfig(bearerToken string, harvesterConfig *Config) *rest.Config {
 	}
 }
 
-// clientOptsV1 is a constructor that sets ups clientbase.ClientOpts the configuration used by the v1 harvester clients.
+// clientOptsV1 is a constructor that sets up a clientbase.ClientOpts the configuration used by the v1 harvester clients.
 func clientOptsV1(restConfig *rest.Config, harvesterConfig *Config) *clientbase.ClientOpts {
 	return &clientbase.ClientOpts{
 		URL:      fmt.Sprintf("https://%s/v1", harvesterConfig.Host),

--- a/clients/rancher/client.go
+++ b/clients/rancher/client.go
@@ -228,16 +228,39 @@ func (c *Client) AsUser(user *management.User) (*Client, error) {
 	return NewClient(returnedToken.Token, c.Session)
 }
 
+// AsUserForConfig accepts a Config and a user object, and then creates a token for said `user`. Then it instantiates and returns a Client using the token created.
+// This function uses the login action, and user must have a correct username and password combination.
+func (c *Client) AsUserForConfig(rancherConfig *Config, user *management.User) (*Client, error) {
+	returnedToken, err := c.login(user)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClientForConfig(returnedToken.Token, rancherConfig, c.Session)
+}
+
 // ReLogin reinstantiates a Client to update its API schema. This function would be used for a non admin user that needs to be
 // "reloaded" inorder to have updated permissions for certain resources.
 func (c *Client) ReLogin() (*Client, error) {
 	return NewClient(c.restConfig.BearerToken, c.Session)
 }
 
+// ReLoginForconfig reinstantiates a Client to update its API schema with the same Config. This function would be used for a non admin user that needs to be
+// "reloaded" inorder to have updated permissions for certain resources.
+func (c *Client) ReLoginForConfig(rancherConfig *Config) (*Client, error) {
+	return NewClientForConfig(c.restConfig.BearerToken, rancherConfig, c.Session)
+}
+
 // WithSession accepts a session.Session and instantiates a new Client to reference this new session.Session. The main purpose is to use it
 // when created "sub sessions" when tracking resources created at a test case scope.
 func (c *Client) WithSession(session *session.Session) (*Client, error) {
 	return NewClient(c.restConfig.BearerToken, session)
+}
+
+// WithSessionForConfig accepts a Config and a session.Session and instantiates a new Client to reference this new session.Session. The main purpose is to use it
+// when created "sub sessions" when tracking resources created at a test case scope.
+func (c *Client) WithSessionForConfig(rancherConfig *Config, session *session.Session) (*Client, error) {
+	return NewClientForConfig(c.restConfig.BearerToken, rancherConfig, session)
 }
 
 // GetClusterCatalogClient is a function that takes a clusterID and instantiates a catalog client to directly communicate with that specific cluster.

--- a/extensions/workloads/pods/pod_status.go
+++ b/extensions/workloads/pods/pod_status.go
@@ -65,7 +65,7 @@ func IsPodReady(pod *v1.SteveAPIObject) (bool, error) {
 		return false, err
 	}
 
-	if podStatus.ContainerStatuses == nil || len(podStatus.ContainerStatuses) == 0 {
+	if len(podStatus.ContainerStatuses) == 0 {
 		return false, nil
 	}
 


### PR DESCRIPTION
## Issue: N/A

## Problem
1. Using the `NewClientForConfig()` Rancher client function with `ReLogin()` or other such functions could result in errors, due to the fact that they default to calling the `NewClient()` function which uses Shepherd's config file loading mechanism. Due to the nature of the `NewClientForConfig()` flow expecting a Config struct to be passed directly (bypassing Shepherd's config loading logic entirely), the referenced functions would fail to load the config file when no such config file exists/is in use.

2. The newly added Harvester client had no mechanism to bypass Shepherd's config file loading mechanism. 

3. `IsPodReady()` in `pod_status.go` had both a `nil` check and a zero-length check for the `ContainerStatuses` slice, but this is unnecessary since a `nil` slice has length == 0.
 
## Solution
1. As a simple solution, I have added `ForConfig` function variants to all functions I have identified to use the `NewClient()` flow.

2. I have added a `NewClientForConfig()` to the Harvester client code, which the `NewClient()` function calls.
   - I have also removed usage of the `environmentflags` package, as the Harvester Client has no reference to `environmentflag.EnvironmentFlags` at all, like the Rancher client does.

3. Removed the `nil` check entirely, leaving only the zero-length check.
 
## Testing
1. This will not cause any regressions as it does not modify existing functions.

2. This should also not cause any regressions as it simply moves the former `NewClient()` flow into `NewClientForConfig()` and has the updated `NewClient()` call `NewClientForConfig()` with the Config that is loaded from file.

3. Utilized the updated `IsPodReady()` locally on many occasions.

Edit: Tested the Rancher and Harvester client package changes locally with @slickwarren's help!

### Regressions Considerations
1. 0%

2. 0% 

3. 0%