### PR TITLE
Update Client timeout to fix test flakiness

### DIFF
--- a/clients/rancher/v1/client.go
+++ b/clients/rancher/v1/client.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	hostRegex = "https://(.+)/v1"
-	duration  = 100 * time.Millisecond // duration of 100 miliseconds to be short since this is a fast check
+	duration  = 300 * time.Millisecond // duration of 100 miliseconds to be short since this is a fast check
 	factor    = 2                      // with a factor of 1
 	steps     = 12                     // only do 12 tries
 )


### PR DESCRIPTION
## Problem
The current timeout for the creation of rancher clients causes certain tests to fail intermittently. In my testing this morning as well as over the last few releases this doesn't happen very frequently but it still occurs often enough to be a problem. 
 
## Solution
Increasing the backoff duration for the client creation. This should allow clients to retry over a longer period of time and should reduce the number of times that this flakiness occurs.
 
## Testing
Ran all tests in the following packages multiple times:
* provisioning/rke2
* provisioning/k3s

### Regressions Considerations
This shouldn't cause any regressions. 
