### PR TITLE
[main] Extend RKE2/K3s restore snapshot time

### DIFF
--- a/extensions/etcdsnapshot/etcdsnapshot.go
+++ b/extensions/etcdsnapshot/etcdsnapshot.go
@@ -254,7 +254,7 @@ func RestoreRKE2K3SSnapshot(client *rancher.Client, snapshotRestore *rkev1.ETCDS
 		return err
 	}
 
-	err = kwait.PollUntilContextTimeout(context.TODO(), 1*time.Second, defaults.TwoMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
+	err = kwait.PollUntilContextTimeout(context.TODO(), 1*time.Second, defaults.ThirtyMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
 		clusterResp, err := client.Steve.SteveType(ProvisioningSteveResouceType).ByID(updatedCluster.ID)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> N/A
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
In our recurring runs for this release testing cycle, it was noted that some snapshot tests were producing a red herring failure. Digging deeper, it is because the restore time has a very short window of two minutes. This needs far more of a buffer as it takes longer than two minutes at times.
 
## Solution
<!-- Describe what you changed or added to fix the issue. Relate your changes back to the original issue and explain why this addresses the issue. -->
Update the timeout to 30 minutes.