### PR TITLE
[v2.12] Extend RKE2/K3s restore snapshot time

### DIFF
--- a/extensions/etcdsnapshot/etcdsnapshot.go
+++ b/extensions/etcdsnapshot/etcdsnapshot.go
@@ -254,7 +254,7 @@ func RestoreRKE2K3SSnapshot(client *rancher.Client, snapshotRestore *rkev1.ETCDS
 		return err
 	}
 
-	err = kwait.PollUntilContextTimeout(context.TODO(), 1*time.Second, defaults.TwoMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
+	err = kwait.PollUntilContextTimeout(context.TODO(), 1*time.Second, defaults.ThirtyMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
 		clusterResp, err := client.Steve.SteveType(ProvisioningSteveResouceType).ByID(updatedCluster.ID)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Backport of https://github.com/rancher/shepherd/pull/427.