### PR TITLE
Add IPv6 params to Node struct

### DIFF
--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -26,12 +26,14 @@ type SSHPath struct {
 
 // Node is a configuration of node that is from an outside cloud provider
 type Node struct {
-	NodeID           string `json:"nodeID" yaml:"nodeID"`
-	PublicIPAddress  string `json:"publicIPAddress" yaml:"publicIPAddress"`
-	PrivateIPAddress string `json:"privateIPAddress" yaml:"privateIPAddress"`
-	SSHUser          string `json:"sshUser" yaml:"sshUser"`
-	SSHKeyName       string `json:"sshKeyName" yaml:"sshKeyName"`
-	SSHKey           []byte
+	NodeID             string `json:"nodeID" yaml:"nodeID"`
+	PublicIPAddress    string `json:"publicIPAddress" yaml:"publicIPAddress"`
+	PrivateIPAddress   string `json:"privateIPAddress" yaml:"privateIPAddress"`
+	PublicIPv6Address  string `json:"publicIPv6Address" yaml:"publicIPv6Address"`
+	PrivateIPv6Address string `json:"privateIPv6Address" yaml:"privateIPv6Address"`
+	SSHUser            string `json:"sshUser" yaml:"sshUser"`
+	SSHKeyName         string `json:"sshKeyName" yaml:"sshKeyName"`
+	SSHKey             []byte
 }
 
 // ExternalNodeConfig is a struct that is a collection of the node configurations


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> N/A
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When hooking up the IPv6 GHA workflows, it was noted of a solution that could work for Jenkins and GHA alike to ensure we can pass our tests with bypassing both pipelines IPv6 limitations.
 
## Solution
<!-- Describe what you changed or added to fix the issue. Relate your changes back to the original issue and explain why this addresses the issue. -->
Update the `Node` struct to have `PublicIPv6Address` and `PrivateIPv6Address`. While a small part here, the corresponding `rancher/tests` PR allows for custom clusters to ssh with the IPv4 address while registering with these values.