### PR TITLE
Add subnetID parameter for EC2

### DIFF
--- a/clients/ec2/config.go
+++ b/clients/ec2/config.go
@@ -17,6 +17,7 @@ type AWSEC2Config struct {
 	AWSRegionAZ        string   `json:"awsRegionAZ" yaml:"awsRegionAZ"`
 	AWSAMI             string   `json:"awsAMI" yaml:"awsAMI"`
 	AWSSecurityGroups  []string `json:"awsSecurityGroups" yaml:"awsSecurityGroups"`
+	AWSSubnetID        string   `json:"awsSubnetID" yaml:"awsSubnetID"`
 	AWSSSHKeyName      string   `json:"awsSSHKeyName" yaml:"awsSSHKeyName"`
 	AWSCICDInstanceTag string   `json:"awsCICDInstanceTag" yaml:"awsCICDInstanceTag"`
 	AWSIAMProfile      string   `json:"awsIAMProfile" yaml:"awsIAMProfile"`


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> N/A
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The current `config.go` does not allow for choosing your own subnet. As part of broader IPv6 support, we need the option to specify an IPv6-only subnet as part of the networking.
 
## Solution
<!-- Describe what you changed or added to fix the issue. Relate your changes back to the original issue and explain why this addresses the issue. -->
Added `AWSSubnetID` parameter.