### PR TITLE
Add OIDC provider client and extensions

### DIFF
--- a/clients/rancher/auth/auth.go
+++ b/clients/rancher/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"github.com/rancher/shepherd/clients/rancher/auth/activedirectory"
+	"github.com/rancher/shepherd/clients/rancher/auth/oidc"
 	"github.com/rancher/shepherd/clients/rancher/auth/openldap"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/pkg/session"
@@ -10,6 +11,7 @@ import (
 type Client struct {
 	OLDAP           *openldap.OLDAPClient
 	ActiveDirectory *activedirectory.Client
+	OIDC            *oidc.APIClient
 }
 
 // NewClient constructs the Auth Provider Struct
@@ -27,5 +29,6 @@ func NewClient(mgmt *management.Client, session *session.Session) (*Client, erro
 	return &Client{
 		OLDAP:           oLDAP,
 		ActiveDirectory: activeDirectory,
+		OIDC:            oidc.NewAPIClient(mgmt.Opts.URL, session),
 	}, nil
 }

--- a/clients/rancher/auth/auth.go
+++ b/clients/rancher/auth/auth.go
@@ -1,15 +1,23 @@
 package auth
 
 import (
+	"strings"
+
 	"github.com/rancher/shepherd/clients/rancher/auth/activedirectory"
+	"github.com/rancher/shepherd/clients/rancher/auth/oidc"
 	"github.com/rancher/shepherd/clients/rancher/auth/openldap"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/pkg/session"
 )
 
+// managementAPIPath is the suffix the management client appends to the Rancher host; the OIDC client
+// addresses paths from the host root, so it must be stripped.
+const managementAPIPath = "/v3"
+
 type Client struct {
 	OLDAP           *openldap.OLDAPClient
 	ActiveDirectory *activedirectory.Client
+	OIDC            *oidc.APIClient
 }
 
 // NewClient constructs the Auth Provider Struct
@@ -24,8 +32,14 @@ func NewClient(mgmt *management.Client, session *session.Session) (*Client, erro
 		return nil, err
 	}
 
+	oidcClient, err := oidc.NewAPIClient(strings.TrimSuffix(mgmt.Opts.URL, managementAPIPath))
+	if err != nil {
+		return nil, err
+	}
+
 	return &Client{
 		OLDAP:           oLDAP,
 		ActiveDirectory: activeDirectory,
+		OIDC:            oidcClient,
 	}, nil
 }

--- a/clients/rancher/auth/oidc/config.go
+++ b/clients/rancher/auth/oidc/config.go
@@ -1,0 +1,25 @@
+package oidc
+
+const (
+	ConfigurationFileKey                 = "oidc"
+	OIDCProviderFeatureFlag              = "oidc-provider"
+	DefaultTokenExpirationSeconds        = 3600
+	DefaultRefreshTokenExpirationSeconds = 86400
+)
+
+var DefaultAutomationScopes = []string{
+	"openid",
+	"profile",
+	"offline_access",
+	"rancher:users",
+}
+
+type Config struct {
+	ClientName                    string   `json:"clientName" yaml:"clientName"`
+	RedirectURI                   string   `json:"redirectURI" yaml:"redirectURI"`
+	Scopes                        []string `json:"scopes" yaml:"scopes"`
+	TokenExpirationSeconds        int      `json:"tokenExpirationSeconds" yaml:"tokenExpirationSeconds"`
+	RefreshTokenExpirationSeconds int      `json:"refreshTokenExpirationSeconds" yaml:"refreshTokenExpirationSeconds"`
+	AdminUsername                 string   `json:"adminUsername" yaml:"adminUsername"`
+	AdminPassword                 string   `json:"adminPassword" yaml:"adminPassword"`
+}

--- a/clients/rancher/auth/oidc/oidc.go
+++ b/clients/rancher/auth/oidc/oidc.go
@@ -1,0 +1,170 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	oidcext "github.com/rancher/shepherd/extensions/auth/oidc"
+	sheptoken "github.com/rancher/shepherd/extensions/token"
+	"github.com/rancher/shepherd/pkg/clientbase"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/sirupsen/logrus"
+)
+
+type APIClient struct {
+	rancherURL       string
+	httpClient       *http.Client
+	noRedirectClient *http.Client
+	Config           *Config
+	session          *session.Session
+}
+
+// NewAPIClient constructs an APIClient and loads the "oidc" config block.
+func NewAPIClient(rancherURL string, session *session.Session) *APIClient {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // nolint:gosec
+	}
+	normalizedURL := strings.TrimRight(rancherURL, "/")
+	if !strings.HasPrefix(normalizedURL, "https://") && !strings.HasPrefix(normalizedURL, "http://") {
+		normalizedURL = "https://" + normalizedURL
+	}
+	oidcConfig := new(Config)
+	config.LoadConfig(ConfigurationFileKey, oidcConfig)
+	return &APIClient{
+		rancherURL: normalizedURL,
+		Config:     oidcConfig,
+		session:    session,
+		httpClient: &http.Client{Transport: transport},
+		noRedirectClient: &http.Client{
+			Transport: transport,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+// GetDiscovery fetches the OIDC provider metadata document.
+func (c *APIClient) GetDiscovery() (*clientbase.Response, map[string]interface{}, error) {
+	return oidcext.Discovery(c.httpClient, c.rancherURL)
+}
+
+// RefreshAccessToken exchanges a refresh_token for a new TokenSet.
+func (c *APIClient) RefreshAccessToken(refreshToken, clientID, clientSecret string) (*oidcext.TokenSet, error) {
+	return oidcext.RefreshAccessToken(c.httpClient, c.rancherURL, refreshToken, clientID, clientSecret)
+}
+
+// RawRequest executes an HTTP request against a Rancher API path.
+func (c *APIClient) RawRequest(method, path, authHeader string) (*clientbase.Response, error) {
+	headers := map[string]string{}
+	if authHeader != "" {
+		headers["Authorization"] = authHeader
+	}
+	return clientbase.Do(c.httpClient, method, c.rancherURL+path, nil, headers)
+}
+
+// CompleteAuthCodeFlow drives the headless PKCE authorization-code flow and returns a TokenSet.
+func (c *APIClient) CompleteAuthCodeFlow(clientID, clientSecret, redirectURI, scopes, username, password string) (*oidcext.TokenSet, error) {
+	const maxAttempts = 5
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		tokenResp, err := sheptoken.GenerateUserToken(&management.User{Username: username, Password: password}, strings.TrimPrefix(c.rancherURL, "https://"))
+		if err != nil {
+			return nil, fmt.Errorf("step 1 (Rancher login): %w", err)
+		}
+		rancherToken := tokenResp.Token
+		pkce, err := oidcext.GeneratePKCE()
+		if err != nil {
+			return nil, fmt.Errorf("step 2 (PKCE generation): %w", err)
+		}
+		state, err := randomState(12)
+		if err != nil {
+			return nil, fmt.Errorf("step 2 (state generation): %w", err)
+		}
+		nonce, err := randomState(12)
+		if err != nil {
+			return nil, fmt.Errorf("step 2 (nonce generation): %w", err)
+		}
+		params := url.Values{
+			"response_type":         {"code"},
+			"client_id":             {clientID},
+			"redirect_uri":          {redirectURI},
+			"scope":                 {scopes},
+			"state":                 {state},
+			"nonce":                 {nonce},
+			"code_challenge":        {pkce.Challenge},
+			"code_challenge_method": {"S256"},
+		}
+		authURL := c.rancherURL + oidcext.OIDCAuthPath + "?" + params.Encode()
+		authResp, err := clientbase.Do(c.noRedirectClient, "GET", authURL, nil, map[string]string{
+			"Authorization": "Bearer " + rancherToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("step 3 (auth endpoint GET): %w", err)
+		}
+		if authResp.StatusCode != http.StatusFound {
+			return nil, fmt.Errorf("step 3 expected 302 from auth endpoint, got %d: %s",
+				authResp.StatusCode, authResp.Body)
+		}
+		location := authResp.Header.Get("Location")
+		if location == "" {
+			return nil, fmt.Errorf("step 4: auth endpoint returned 302 but no Location header")
+		}
+		if strings.Contains(location, "/dashboard/auth/login") {
+			logrus.Infof("step 4: auth endpoint redirected to dashboard login — Rancher session token was rejected, retrying")
+			continue
+		}
+		redirectParsed, err := url.Parse(location)
+		if err != nil {
+			return nil, fmt.Errorf("step 4: parsing Location URL %q: %w", location, err)
+		}
+		authCode := redirectParsed.Query().Get("code")
+		if authCode == "" {
+			return nil, fmt.Errorf("step 4: no 'code' parameter in redirect Location %q", location)
+		}
+		if redirectParsed.Query().Get("state") != state {
+			return nil, fmt.Errorf("step 4: state mismatch")
+		}
+		body := url.Values{
+			"grant_type":    {"authorization_code"},
+			"code":          {authCode},
+			"code_verifier": {pkce.Verifier},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"redirect_uri":  {redirectURI},
+		}
+		resp, err := clientbase.Do(c.httpClient, "POST", c.rancherURL+oidcext.OIDCTokenPath, body, map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("token exchange POST: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("token exchange returned %d: %s", resp.StatusCode, resp.Body)
+		}
+		var ts oidcext.TokenSet
+		if err := json.Unmarshal(resp.Body, &ts); err != nil {
+			return nil, fmt.Errorf("parsing token response: %w", err)
+		}
+		if ts.AccessToken == "" {
+			return nil, fmt.Errorf("token response missing access_token field")
+		}
+		return &ts, nil
+	}
+	return nil, fmt.Errorf("PKCE auth flow failed after %d attempts", maxAttempts)
+}
+
+func randomState(n int) (string, error) {
+	raw := make([]byte, n)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generating random state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}

--- a/clients/rancher/auth/oidc/oidc.go
+++ b/clients/rancher/auth/oidc/oidc.go
@@ -1,0 +1,183 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	oidcext "github.com/rancher/shepherd/extensions/auth/oidc"
+	sheptoken "github.com/rancher/shepherd/extensions/token"
+	"github.com/rancher/shepherd/pkg/clientbase"
+	"github.com/sirupsen/logrus"
+)
+
+// defaultTimeout bounds every OIDC request so a stalled connection cannot hang a test run.
+const defaultTimeout = time.Minute
+
+type APIClient struct {
+	rancherURL       string
+	rancherHost      string
+	httpClient       *http.Client
+	noRedirectClient *http.Client
+}
+
+// NewAPIClient constructs an APIClient against the given Rancher URL, defaulting to https when the
+// URL carries no scheme.
+func NewAPIClient(rancherURL string) (*APIClient, error) {
+	normalizedURL := strings.TrimRight(rancherURL, "/")
+	if !strings.HasPrefix(normalizedURL, "https://") && !strings.HasPrefix(normalizedURL, "http://") {
+		normalizedURL = "https://" + normalizedURL
+	}
+
+	parsedURL, err := url.Parse(normalizedURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing Rancher URL %s: %w", rancherURL, err)
+	}
+	if parsedURL.Host == "" {
+		return nil, fmt.Errorf("Rancher URL %s has no host", rancherURL)
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // nolint:gosec
+	}
+
+	return &APIClient{
+		rancherURL:  normalizedURL,
+		rancherHost: parsedURL.Host,
+		httpClient:  &http.Client{Transport: transport, Timeout: defaultTimeout},
+		noRedirectClient: &http.Client{
+			Transport: transport,
+			Timeout:   defaultTimeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}, nil
+}
+
+// GetDiscovery fetches the OIDC provider metadata document.
+func (c *APIClient) GetDiscovery() (*clientbase.Response, map[string]interface{}, error) {
+	return oidcext.Discovery(c.httpClient, c.rancherURL)
+}
+
+// RefreshAccessToken exchanges a refresh_token for a new TokenSet.
+func (c *APIClient) RefreshAccessToken(refreshToken, clientID, clientSecret string) (*oidcext.TokenSet, error) {
+	return oidcext.RefreshAccessToken(c.httpClient, c.rancherURL, refreshToken, clientID, clientSecret)
+}
+
+// RawRequest executes an HTTP request against a Rancher API path. A non-nil body is sent as JSON.
+func (c *APIClient) RawRequest(method, path, authHeader string, body interface{}) (*clientbase.Response, error) {
+	headers := map[string]string{}
+	if authHeader != "" {
+		headers["Authorization"] = authHeader
+	}
+	if body != nil {
+		headers["Content-Type"] = "application/json"
+	}
+	return clientbase.Do(c.httpClient, method, c.rancherURL+path, body, headers)
+}
+
+// CompleteAuthCodeFlow drives the headless PKCE authorization-code flow and returns a TokenSet.
+func (c *APIClient) CompleteAuthCodeFlow(clientID, clientSecret, redirectURI, scopes, username, password string) (*oidcext.TokenSet, error) {
+	const maxAttempts = 5
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		tokenResp, err := sheptoken.GenerateUserToken(&management.User{Username: username, Password: password}, c.rancherHost)
+		if err != nil {
+			return nil, fmt.Errorf("step 1 (Rancher login): %w", err)
+		}
+		rancherToken := tokenResp.Token
+		pkce, err := oidcext.GeneratePKCE()
+		if err != nil {
+			return nil, fmt.Errorf("step 2 (PKCE generation): %w", err)
+		}
+		state, err := randomState(12)
+		if err != nil {
+			return nil, fmt.Errorf("step 2 (state generation): %w", err)
+		}
+		nonce, err := randomState(12)
+		if err != nil {
+			return nil, fmt.Errorf("step 2 (nonce generation): %w", err)
+		}
+		params := url.Values{
+			"response_type":         {"code"},
+			"client_id":             {clientID},
+			"redirect_uri":          {redirectURI},
+			"scope":                 {scopes},
+			"state":                 {state},
+			"nonce":                 {nonce},
+			"code_challenge":        {pkce.Challenge},
+			"code_challenge_method": {"S256"},
+		}
+		authURL := c.rancherURL + oidcext.OIDCAuthPath + "?" + params.Encode()
+		authResp, err := clientbase.Do(c.noRedirectClient, "GET", authURL, nil, map[string]string{
+			"Authorization": "Bearer " + rancherToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("step 3 (auth endpoint GET): %w", err)
+		}
+		if authResp.StatusCode != http.StatusFound {
+			return nil, fmt.Errorf("step 3 expected 302 from auth endpoint, got %d: %s",
+				authResp.StatusCode, authResp.Body)
+		}
+		location := authResp.Header.Get("Location")
+		if location == "" {
+			return nil, fmt.Errorf("step 4: auth endpoint returned 302 but no Location header")
+		}
+		if strings.Contains(location, "/dashboard/auth/login") {
+			logrus.Infof("step 4: auth endpoint redirected to dashboard login — Rancher session token was rejected, retrying")
+			continue
+		}
+		redirectParsed, err := url.Parse(location)
+		if err != nil {
+			return nil, fmt.Errorf("step 4: parsing Location URL %q: %w", location, err)
+		}
+		authCode := redirectParsed.Query().Get("code")
+		if authCode == "" {
+			return nil, fmt.Errorf("step 4: no 'code' parameter in redirect Location %q", location)
+		}
+		if redirectParsed.Query().Get("state") != state {
+			return nil, fmt.Errorf("step 4: state mismatch")
+		}
+		body := url.Values{
+			"grant_type":    {"authorization_code"},
+			"code":          {authCode},
+			"code_verifier": {pkce.Verifier},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"redirect_uri":  {redirectURI},
+		}
+		resp, err := clientbase.Do(c.httpClient, "POST", c.rancherURL+oidcext.OIDCTokenPath, body, map[string]string{
+			"Content-Type": "application/x-www-form-urlencoded",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("token exchange POST: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("token exchange returned %d: %s", resp.StatusCode, resp.Body)
+		}
+		var ts oidcext.TokenSet
+		if err := json.Unmarshal(resp.Body, &ts); err != nil {
+			return nil, fmt.Errorf("parsing token response: %w", err)
+		}
+		if ts.AccessToken == "" {
+			return nil, fmt.Errorf("token response missing access_token field")
+		}
+		return &ts, nil
+	}
+	return nil, fmt.Errorf("PKCE auth flow failed after %d attempts", maxAttempts)
+}
+
+func randomState(n int) (string, error) {
+	raw := make([]byte, n)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generating random state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}

--- a/clients/rancher/auth/scim/client.go
+++ b/clients/rancher/auth/scim/client.go
@@ -1,12 +1,10 @@
 package scim
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -89,34 +87,17 @@ func (t *scimTransport) do(method, resource, id string, query url.Values, body i
 		rawURL += "?" + query.Encode()
 	}
 
-	var bodyReader io.Reader
-	if body != nil {
-		b, err := json.Marshal(body)
-		if err != nil {
-			return nil, err
-		}
-		bodyReader = bytes.NewReader(b)
+	headers := map[string]string{
+		"Authorization": "Bearer " + t.token,
+		"Content-Type":  "application/scim+json",
+		"Accept":        "application/scim+json",
 	}
 
-	req, err := http.NewRequest(method, rawURL, bodyReader)
+	resp, err := clientbase.Do(t.httpClient, method, rawURL, body, headers)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+t.token)
-	req.Header.Set("Content-Type", "application/scim+json")
-	req.Header.Set("Accept", "application/scim+json")
-
-	resp, err := t.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return &Response{StatusCode: resp.StatusCode, Body: respBody, Header: resp.Header}, nil
+	return &Response{StatusCode: resp.StatusCode, Body: resp.Body, Header: resp.Header}, nil
 }
 
 // Users is the interface for SCIM User operations.

--- a/extensions/auth/oidc/jwt.go
+++ b/extensions/auth/oidc/jwt.go
@@ -1,0 +1,39 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// DecodeJWTPayload decodes the payload section of a JWT without verifying the signature.
+func DecodeJWTPayload(token string) (map[string]interface{}, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT structure: expected 3 parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decoding JWT payload: %w", err)
+	}
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("parsing JWT claims: %w", err)
+	}
+	return claims, nil
+}
+
+// TamperJWTSignature replaces the signature segment of a JWT with random bytes.
+func TamperJWTSignature(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT: cannot tamper signature")
+	}
+	fakeSig := make([]byte, 32)
+	if _, err := rand.Read(fakeSig); err != nil {
+		return "", fmt.Errorf("generating fake signature: %w", err)
+	}
+	return parts[0] + "." + parts[1] + "." + base64.RawURLEncoding.EncodeToString(fakeSig), nil
+}

--- a/extensions/auth/oidc/jwt.go
+++ b/extensions/auth/oidc/jwt.go
@@ -1,0 +1,56 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// DecodeJWTPayload decodes the payload section of a JWT without verifying the signature.
+func DecodeJWTPayload(token string) (map[string]interface{}, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT structure: expected 3 parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decoding JWT payload: %w", err)
+	}
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("parsing JWT claims: %w", err)
+	}
+	return claims, nil
+}
+
+// TamperJWTSignature replaces the signature segment of a JWT with random bytes.
+func TamperJWTSignature(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT: cannot tamper signature")
+	}
+	fakeSig := make([]byte, 32)
+	if _, err := rand.Read(fakeSig); err != nil {
+		return "", fmt.Errorf("generating fake signature: %w", err)
+	}
+	return parts[0] + "." + parts[1] + "." + base64.RawURLEncoding.EncodeToString(fakeSig), nil
+}
+
+// CraftJWTWithNonStringKid returns an unsigned JWT whose header "kid" field is an integer rather
+// than a string, used to verify that providers reject it instead of panicking on the type assertion.
+func CraftJWTWithNonStringKid() (string, error) {
+	header, err := json.Marshal(map[string]interface{}{"alg": "RS256", "typ": "JWT", "kid": 12345})
+	if err != nil {
+		return "", fmt.Errorf("marshaling JWT header: %w", err)
+	}
+
+	payload, err := json.Marshal(map[string]interface{}{"sub": "test-user", "iss": "https://test.example.com", "exp": int64(9999999999)})
+	if err != nil {
+		return "", fmt.Errorf("marshaling JWT payload: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(header) + "." +
+		base64.RawURLEncoding.EncodeToString(payload) + ".fakesignature", nil
+}

--- a/extensions/auth/oidc/oidc.go
+++ b/extensions/auth/oidc/oidc.go
@@ -1,0 +1,69 @@
+package oidc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/rancher/shepherd/pkg/clientbase"
+)
+
+const (
+	OIDCClientGroup    = "management.cattle.io"
+	OIDCClientVersion  = "v3"
+	OIDCClientResource = "oidcclients"
+	OIDCClientKind     = "OIDCClient"
+
+	OIDCDiscoveryPath = "/oidc/.well-known/openid-configuration"
+	OIDCAuthPath      = "/oidc/authorize"
+	OIDCTokenPath     = "/oidc/token"
+	UsersPath         = "/v3/users"
+	ClustersPath      = "/v3/clusters"
+)
+
+type TokenSet struct {
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	Scope        string `json:"scope"`
+}
+
+// Discovery fetches the OIDC provider metadata document.
+func Discovery(httpClient *http.Client, rancherURL string) (*clientbase.Response, map[string]interface{}, error) {
+	resp, err := clientbase.Do(httpClient, "GET", rancherURL+OIDCDiscoveryPath, nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching OIDC discovery: %w", err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &doc); err != nil {
+		return resp, nil, fmt.Errorf("parsing discovery document: %w", err)
+	}
+	return resp, doc, nil
+}
+
+// RefreshAccessToken exchanges a refresh_token for a new TokenSet.
+func RefreshAccessToken(httpClient *http.Client, rancherURL, refreshToken, clientID, clientSecret string) (*TokenSet, error) {
+	body := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+	}
+	resp, err := clientbase.Do(httpClient, "POST", rancherURL+OIDCTokenPath, body, map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("refresh token POST: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("refresh returned %d: %s", resp.StatusCode, resp.Body)
+	}
+	var ts TokenSet
+	if err := json.Unmarshal(resp.Body, &ts); err != nil {
+		return nil, fmt.Errorf("parsing refresh response: %w", err)
+	}
+	return &ts, nil
+}

--- a/extensions/auth/oidc/oidc.go
+++ b/extensions/auth/oidc/oidc.go
@@ -1,0 +1,66 @@
+package oidc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/rancher/shepherd/pkg/clientbase"
+)
+
+const (
+	OIDCDiscoveryPath    = "/oidc/.well-known/openid-configuration"
+	OIDCAuthPath         = "/oidc/authorize"
+	OIDCTokenPath        = "/oidc/token"
+	OIDCClientsPath      = "/v3/oidcclients"
+	OIDCClientSchemaPath = "/v3/schemas/oidcclient"
+	UsersPath            = "/v3/users"
+	ClustersPath         = "/v3/clusters"
+)
+
+type TokenSet struct {
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	Scope        string `json:"scope"`
+}
+
+// Discovery fetches the OIDC provider metadata document.
+func Discovery(httpClient *http.Client, rancherURL string) (*clientbase.Response, map[string]interface{}, error) {
+	resp, err := clientbase.Do(httpClient, "GET", rancherURL+OIDCDiscoveryPath, nil, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching OIDC discovery: %w", err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &doc); err != nil {
+		return resp, nil, fmt.Errorf("parsing discovery document (HTTP %d): %w", resp.StatusCode, err)
+	}
+	return resp, doc, nil
+}
+
+// RefreshAccessToken exchanges a refresh_token for a new TokenSet.
+func RefreshAccessToken(httpClient *http.Client, rancherURL, refreshToken, clientID, clientSecret string) (*TokenSet, error) {
+	body := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+	}
+	resp, err := clientbase.Do(httpClient, "POST", rancherURL+OIDCTokenPath, body, map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("refresh token POST: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("refresh returned %d: %s", resp.StatusCode, resp.Body)
+	}
+	var ts TokenSet
+	if err := json.Unmarshal(resp.Body, &ts); err != nil {
+		return nil, fmt.Errorf("parsing refresh response: %w", err)
+	}
+	return &ts, nil
+}

--- a/extensions/auth/oidc/pkce.go
+++ b/extensions/auth/oidc/pkce.go
@@ -1,0 +1,25 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+)
+
+type PKCEPair struct {
+	Verifier  string
+	Challenge string
+}
+
+// GeneratePKCE creates a fresh PKCE verifier/challenge pair using the S256 method.
+func GeneratePKCE() (PKCEPair, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return PKCEPair{}, fmt.Errorf("generating PKCE verifier entropy: %w", err)
+	}
+	verifier := base64.RawURLEncoding.EncodeToString(raw)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	return PKCEPair{Verifier: verifier, Challenge: challenge}, nil
+}

--- a/extensions/kubeapi/auth/oidcclient/oidcclient.go
+++ b/extensions/kubeapi/auth/oidcclient/oidcclient.go
@@ -1,0 +1,155 @@
+package oidcclient
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	oidcext "github.com/rancher/shepherd/extensions/auth/oidc"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const OIDCClientSecretNamespace = "cattle-oidc-client-secrets"
+
+var oidcClientGVR = schema.GroupVersionResource{
+	Group:    oidcext.OIDCClientGroup,
+	Version:  oidcext.OIDCClientVersion,
+	Resource: oidcext.OIDCClientResource,
+}
+
+type ClientSpec struct {
+	RedirectURIs                  []string
+	Scopes                        []string
+	TokenExpirationSeconds        int
+	RefreshTokenExpirationSeconds int
+}
+
+// CreateOIDCClient creates an OIDCClient CRD and registers DeleteOIDCClient as session cleanup.
+func CreateOIDCClient(client *rancher.Client, name string, spec ClientSpec) error {
+	logrus.Infof("[OIDC setup] Creating OIDCClient CRD %q on management cluster", name)
+	redirectURIs := make([]interface{}, len(spec.RedirectURIs))
+	for i, v := range spec.RedirectURIs {
+		redirectURIs[i] = v
+	}
+	scopes := make([]interface{}, len(spec.Scopes))
+	for i, v := range spec.Scopes {
+		scopes[i] = v
+	}
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": oidcext.OIDCClientGroup + "/" + oidcext.OIDCClientVersion,
+			"kind":       oidcext.OIDCClientKind,
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+			"spec": map[string]interface{}{
+				"redirectURIs":                  redirectURIs,
+				"scopes":                        scopes,
+				"tokenExpirationSeconds":        int64(spec.TokenExpirationSeconds),
+				"refreshTokenExpirationSeconds": int64(spec.RefreshTokenExpirationSeconds),
+			},
+		},
+	}
+	dynClient, err := client.GetRancherDynamicClient()
+	if err != nil {
+		return err
+	}
+	_, err = dynClient.Resource(oidcClientGVR).Create(context.Background(), obj, metav1.CreateOptions{})
+	if err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return fmt.Errorf("creating OIDCClient %q: %w", name, err)
+		}
+		logrus.Infof("[OIDC setup] OIDCClient %q already exists — skipping creation", name)
+		return nil
+	}
+	logrus.Infof("[OIDC setup] OIDCClient %q created", name)
+	client.Session.RegisterCleanupFunc(func() error {
+		return DeleteOIDCClient(client, name)
+	})
+	return nil
+}
+
+// WaitForOIDCClientReady polls until status.clientID and status.clientSecrets are populated.
+func WaitForOIDCClientReady(client *rancher.Client, name string) (clientID, secretKeyName string, err error) {
+	logrus.Infof("[OIDC setup] Waiting for OIDCClient %q status.clientID (max 2m)", name)
+	dynClient, err := client.GetRancherDynamicClient()
+	if err != nil {
+		return "", "", err
+	}
+	err = kwait.PollUntilContextTimeout(
+		context.Background(), defaults.FiveSecondTimeout, defaults.TwoMinuteTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			obj, getErr := dynClient.Resource(oidcClientGVR).Get(ctx, name, metav1.GetOptions{})
+			if getErr != nil {
+				logrus.Debugf("[OIDC] OIDCClient %q not yet visible: %v", name, getErr)
+				return false, nil
+			}
+			status, ok := obj.Object["status"].(map[string]interface{})
+			if !ok {
+				return false, nil
+			}
+			id, _ := status["clientID"].(string)
+			if id == "" {
+				return false, nil
+			}
+			secrets, _ := status["clientSecrets"].(map[string]interface{})
+			if len(secrets) == 0 {
+				return false, nil
+			}
+			for k := range secrets {
+				secretKeyName = k
+				break
+			}
+			clientID = id
+			logrus.Infof("[OIDC] OIDCClient %q ready — clientID=%s secretKey=%s", name, clientID, secretKeyName)
+			return true, nil
+		},
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("timed out waiting for OIDCClient %q status.clientID: %w", name, err)
+	}
+	return clientID, secretKeyName, nil
+}
+
+// FetchOIDCClientSecret retrieves the OIDCClient secret value from the cattle-oidc-client-secrets namespace.
+func FetchOIDCClientSecret(client *rancher.Client, clientID, secretKeyName string) (string, error) {
+	logrus.Infof("[OIDC setup] Fetching client secret from %s/%s key=%s",
+		OIDCClientSecretNamespace, clientID, secretKeyName)
+	secret, err := client.WranglerContext.Core.Secret().Get(
+		OIDCClientSecretNamespace, clientID, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting OIDCClient secret %s/%s: %w",
+			OIDCClientSecretNamespace, clientID, err)
+	}
+	value, ok := secret.Data[secretKeyName]
+	if !ok || len(value) == 0 {
+		return "", fmt.Errorf("key %q not found or empty in secret %s/%s",
+			secretKeyName, OIDCClientSecretNamespace, clientID)
+	}
+	return string(value), nil
+}
+
+// DeleteOIDCClient deletes the OIDCClient by name; NotFound is treated as success.
+func DeleteOIDCClient(client *rancher.Client, name string) error {
+	logrus.Infof("[OIDC teardown] Deleting OIDCClient %q", name)
+	dynClient, err := client.GetRancherDynamicClient()
+	if err != nil {
+		return err
+	}
+	err = dynClient.Resource(oidcClientGVR).Delete(context.Background(), name, metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			logrus.Debugf("[OIDC teardown] OIDCClient %q already gone — skipping", name)
+			return nil
+		}
+		return fmt.Errorf("deleting OIDCClient %q: %w", name, err)
+	}
+	logrus.Infof("[OIDC teardown] OIDCClient %q deleted", name)
+	return nil
+}

--- a/extensions/kubeapi/auth/oidcclient/oidcclient.go
+++ b/extensions/kubeapi/auth/oidcclient/oidcclient.go
@@ -1,0 +1,98 @@
+package oidcclient
+
+import (
+	"context"
+	"fmt"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const OIDCClientSecretNamespace = "cattle-oidc-client-secrets"
+
+// CreateOIDCClient creates an OIDCClient and registers DeleteOIDCClient as session cleanup.
+func CreateOIDCClient(client *rancher.Client, name string, spec v3.OIDCClientSpec) (*v3.OIDCClient, error) {
+	oidcClient := &v3.OIDCClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: spec,
+	}
+
+	createdClient, err := client.WranglerContext.Mgmt.OIDCClient().Create(oidcClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OIDCClient %s: %w", name, err)
+	}
+
+	client.Session.RegisterCleanupFunc(func() error {
+		return DeleteOIDCClient(client, name)
+	})
+
+	return createdClient, nil
+}
+
+// WaitForOIDCClientReady polls until the OIDCClient reports a client ID and at least one client
+// secret, returning the client ID and the name of the first secret key.
+func WaitForOIDCClientReady(client *rancher.Client, name string) (string, string, error) {
+	var clientID, secretKeyName string
+
+	err := kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.TwoMinuteTimeout, true, func(ctx context.Context) (bool, error) {
+		oidcClient, err := client.WranglerContext.Mgmt.OIDCClient().Get(name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		if oidcClient.Status.ClientID == "" || len(oidcClient.Status.ClientSecrets) == 0 {
+			return false, nil
+		}
+
+		clientID = oidcClient.Status.ClientID
+		for key := range oidcClient.Status.ClientSecrets {
+			secretKeyName = key
+			break
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("timed out waiting for OIDCClient %s to report a client ID and secret: %w", name, err)
+	}
+
+	logrus.Infof("OIDCClient %s is ready with client ID %s", name, clientID)
+
+	return clientID, secretKeyName, nil
+}
+
+// FetchOIDCClientSecret returns the OIDCClient secret value stored under the given key.
+func FetchOIDCClientSecret(client *rancher.Client, clientID, secretKeyName string) (string, error) {
+	secret, err := client.WranglerContext.Core.Secret().Get(OIDCClientSecretNamespace, clientID, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get OIDCClient secret %s/%s: %w", OIDCClientSecretNamespace, clientID, err)
+	}
+
+	value, ok := secret.Data[secretKeyName]
+	if !ok || len(value) == 0 {
+		return "", fmt.Errorf("key %s not found or empty in secret %s/%s", secretKeyName, OIDCClientSecretNamespace, clientID)
+	}
+
+	return string(value), nil
+}
+
+// DeleteOIDCClient deletes the OIDCClient with the given name, treating NotFound as success.
+func DeleteOIDCClient(client *rancher.Client, name string) error {
+	err := client.WranglerContext.Mgmt.OIDCClient().Delete(name, &metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete OIDCClient %s: %w", name, err)
+	}
+
+	return nil
+}

--- a/extensions/kubeapi/features/features.go
+++ b/extensions/kubeapi/features/features.go
@@ -1,0 +1,52 @@
+package features
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IsFeatureEnabled returns true when the named feature flag is enabled.
+func IsFeatureEnabled(client *rancher.Client, name string) (bool, error) {
+	feature, err := client.WranglerContext.Mgmt.Feature().Get(name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	if feature.Spec.Value == nil {
+		return false, nil
+	}
+	return *feature.Spec.Value, nil
+}
+
+// UpdateFeatureFlag sets the named feature flag to value; no-op if already at value.
+func UpdateFeatureFlag(client *rancher.Client, name string, value bool) error {
+	feature, err := client.WranglerContext.Mgmt.Feature().Get(name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if feature.Spec.Value != nil && *feature.Spec.Value == value {
+		return nil
+	}
+	feature.Spec.Value = &value
+	_, err = client.WranglerContext.Mgmt.Feature().Update(feature)
+	return err
+}
+
+// EnableFeatureFlag enables the named feature flag and registers DisableFeatureFlag as session cleanup.
+func EnableFeatureFlag(client *rancher.Client, name string) error {
+	enabled, err := IsFeatureEnabled(client, name)
+	if err != nil {
+		return err
+	}
+	if enabled {
+		return nil
+	}
+	client.Session.RegisterCleanupFunc(func() error {
+		return DisableFeatureFlag(client, name)
+	})
+	return UpdateFeatureFlag(client, name, true)
+}
+
+// DisableFeatureFlag disables the named feature flag.
+func DisableFeatureFlag(client *rancher.Client, name string) error {
+	return UpdateFeatureFlag(client, name, false)
+}

--- a/extensions/kubeapi/features/features.go
+++ b/extensions/kubeapi/features/features.go
@@ -2,6 +2,9 @@ package features
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	"github.com/rancher/shepherd/extensions/kubeapi/workloads/deployments"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,7 +39,9 @@ func UpdateFeatureFlag(client *rancher.Client, name string, value bool) error {
 	return err
 }
 
-// EnableFeatureFlag enables the named feature flag and registers DisableFeatureFlag as session cleanup.
+// EnableFeatureFlag enables the named feature flag and registers session cleanup that disables it again
+// and waits for the Rancher rollout to settle, so cleanup does not hand back a restarting server. The flag
+// is left untouched, and no cleanup registered, when it is already enabled.
 func EnableFeatureFlag(client *rancher.Client, name string) error {
 	enabled, err := IsFeatureEnabled(client, name)
 	if err != nil {
@@ -48,7 +53,17 @@ func EnableFeatureFlag(client *rancher.Client, name string) error {
 	}
 
 	client.Session.RegisterCleanupFunc(func() error {
-		return DisableFeatureFlag(client, name)
+		if err := DisableFeatureFlag(client, name); err != nil {
+			return err
+		}
+
+		// The session retries a cleanup func that returns an error, and re-waiting a rollout that already
+		// timed out only multiplies the delay, so the wait is reported rather than returned.
+		if err := deployments.WaitForDeploymentActive(client, cluster.LocalCluster, deployments.RancherDeploymentNamespace, deployments.RancherDeploymentName); err != nil {
+			logrus.Errorf("rancher did not settle after disabling feature flag %s: %v", name, err)
+		}
+
+		return nil
 	})
 
 	return UpdateFeatureFlag(client, name, true)

--- a/extensions/kubeapi/workloads/deployments/deployments.go
+++ b/extensions/kubeapi/workloads/deployments/deployments.go
@@ -1,0 +1,44 @@
+package deployments
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	RancherDeploymentName      = "rancher"
+	RancherDeploymentNamespace = "cattle-system"
+)
+
+// WaitForDeploymentActive polls until the deployment has all replicas updated, ready, and available.
+func WaitForDeploymentActive(client *rancher.Client, clusterID, namespaceName, deploymentName string) error {
+	wranglerContext, err := cluster.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return fmt.Errorf("getting wrangler context for cluster %s: %w", clusterID, err)
+	}
+	return kwait.PollUntilContextTimeout(
+		context.Background(), defaults.TenSecondTimeout, defaults.FiveMinuteTimeout, false,
+		func(ctx context.Context) (bool, error) {
+			d, err := wranglerContext.Apps.Deployment().Get(namespaceName, deploymentName, metav1.GetOptions{})
+			if err != nil {
+				logrus.Debugf("waiting for deployment %s/%s: %v", namespaceName, deploymentName, err)
+				return false, nil
+			}
+			if d.Spec.Replicas == nil {
+				return false, nil
+			}
+			desired := *d.Spec.Replicas
+			return d.Status.UpdatedReplicas == desired &&
+				d.Status.ReadyReplicas == desired &&
+				d.Status.AvailableReplicas == desired &&
+				d.Status.Replicas == desired, nil
+		},
+	)
+}

--- a/extensions/kubeapi/workloads/deployments/deployments.go
+++ b/extensions/kubeapi/workloads/deployments/deployments.go
@@ -12,6 +12,11 @@ import (
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
+const (
+	RancherDeploymentName      = "rancher"
+	RancherDeploymentNamespace = "cattle-system"
+)
+
 // GetDeploymentByName returns a Deployment by name and namespace using wrangler context.
 func GetDeploymentByName(client *rancher.Client, clusterID, deploymentNamespace, deploymentName string) (*appsv1.Deployment, error) {
 	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
@@ -41,6 +46,7 @@ func WaitForDeploymentActive(client *rancher.Client, clusterID, deploymentNamesp
 
 		desired := *deployment.Spec.Replicas
 		return deployment.Status.UpdatedReplicas == desired &&
+			deployment.Status.ReadyReplicas == desired &&
 			deployment.Status.AvailableReplicas == desired &&
 			deployment.Status.Replicas == desired, nil
 	})

--- a/pkg/clientbase/raw.go
+++ b/pkg/clientbase/raw.go
@@ -1,0 +1,58 @@
+package clientbase
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type Response struct {
+	StatusCode int
+	Body       []byte
+	Header     http.Header
+}
+
+// Do executes a raw HTTP request; body may be url.Values (form-encoded) or any JSON-serializable value.
+func Do(client *http.Client, method, rawURL string, body interface{}, headers map[string]string) (*Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		switch v := body.(type) {
+		case url.Values:
+			bodyReader = strings.NewReader(v.Encode())
+		default:
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("marshaling request body: %w", err)
+			}
+			bodyReader = bytes.NewReader(b)
+		}
+	}
+	req, err := http.NewRequest(method, rawURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("creating request %s %s: %w", method, rawURL, err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request %s %s: %w", method, rawURL, err)
+	}
+	defer func() {
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		resp.Body.Close()              //nolint:errcheck
+	}()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body from %s %s: %w", method, rawURL, err)
+	}
+	return &Response{
+		StatusCode: resp.StatusCode,
+		Body:       respBody,
+		Header:     resp.Header,
+	}, nil
+}

--- a/pkg/clientbase/raw.go
+++ b/pkg/clientbase/raw.go
@@ -1,0 +1,66 @@
+package clientbase
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type Response struct {
+	StatusCode int
+	Body       []byte
+	Header     http.Header
+}
+
+// RawHttpRequest executes a request against an arbitrary URL using the client's configured transport,
+// bypassing schema resolution. Use this for Rancher endpoints that are not registered in the API schema.
+// Callers that need a request before an authenticated client exists, or that need a differently
+// configured transport such as one that does not follow redirects, should call Do directly.
+func (a *APIOperations) RawHttpRequest(method, rawURL string, body interface{}, headers map[string]string) (*Response, error) {
+	return Do(a.Client, method, rawURL, body, headers)
+}
+
+// Do executes a raw HTTP request; body may be url.Values (form-encoded) or any JSON-serializable value.
+func Do(client *http.Client, method, rawURL string, body interface{}, headers map[string]string) (*Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		switch v := body.(type) {
+		case url.Values:
+			bodyReader = strings.NewReader(v.Encode())
+		default:
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("marshaling request body: %w", err)
+			}
+			bodyReader = bytes.NewReader(b)
+		}
+	}
+	req, err := http.NewRequest(method, rawURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("creating request %s %s: %w", method, rawURL, err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request %s %s: %w", method, rawURL, err)
+	}
+	defer func() {
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		resp.Body.Close()              //nolint:errcheck
+	}()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body from %s %s: %w", method, rawURL, err)
+	}
+	return &Response{
+		StatusCode: resp.StatusCode,
+		Body:       respBody,
+		Header:     resp.Header,
+	}, nil
+}


### PR DESCRIPTION
Adds the OIDC provider client and extensions needed for the OIDC/OAuth2 automation suite.

Related: https://github.com/rancher/rancher/issues/52716
Consumed by: https://github.com/rancher/tests/pull/602

## What's here

- **`extensions/auth/oidc/`** — raw-HTTP helpers for the provider endpoints (discovery, refresh), PKCE generation, and JWT utilities.
- **`extensions/kubeapi/auth/oidcclient/`** — typed wrangler CRUD for the `OIDCClient` CRD and its generated secret.
- **`clients/rancher/auth/oidc/`** — the provider client, wired into `auth.Client` as `client.Auth.OIDC`, plus the test config struct.
- **`pkg/clientbase/raw.go`** — shared raw HTTP `Do`/`Response`. The SCIM client's private `do` is refactored onto it (−31 lines), so this is a net dedup rather than a new layer.
- **`extensions/kubeapi/workloads/deployments/`** — adds the canonical `rancher`/`cattle-system` consts and makes `WaitForDeploymentActive` check `ReadyReplicas` against desired, so feature-flag restarts are detected reliably.

## 🧠 Helper Classification — `classify-helper-type` Skill Applied

> All new symbols were audited using [@Priyashetty17](https://github.com/Priyashetty17)'s [`classify-helper-type-validation-tests`](https://github.com/rancherlabs/ai-sandbox/pull/1) skill before placement.
> Reference: [Actions vs Extensions — Confluence](https://confluence.suse.com/spaces/RANQA/pages/1505559041/Actions+vs+Extensions)

Symbol | Location | Bucket | Rubric Criterion
-- | -- | -- | --
`Discovery(httpClient, rancherURL)` | `extensions/auth/oidc/oidc.go` | Extension | Bridges API/client gap (raw HTTP); generic params; no defaults
`RefreshAccessToken(httpClient, rancherURL, ...)` | `extensions/auth/oidc/oidc.go` | Extension | Same as Discovery — raw HTTP, generic params
`GeneratePKCE()` | `extensions/auth/oidc/pkce.go` | Extension | Pure utility; no defaults; reusable outside rancher/rancher
`DecodeJWTPayload`, `TamperJWTSignature`, `CraftJWTWithNonStringKid` | `extensions/auth/oidc/jwt.go` | Extension | Pure utilities; no defaults. `CraftJWTWithNonStringKid` was moved out of the test file so the malformed-token fixture is reusable
OIDC path consts, `TokenSet`, `PKCEPair` | `extensions/auth/oidc/` | Extension | Structs and Templates — plain data types reusable across projects
`CreateOIDCClient(client, name, spec)` | `extensions/kubeapi/auth/oidcclient/oidcclient.go` | Extension | Generic singular Create via typed wrangler client; no defaults applied — caller passes the full spec; registers session cleanup
`WaitForOIDCClientReady(client, name)` | `extensions/kubeapi/auth/oidcclient/oidcclient.go` | Extension | "Waits are acceptable" — generic CRD-status wait, no test assertions
`FetchOIDCClientSecret(client, clientID, key)` | `extensions/kubeapi/auth/oidcclient/oidcclient.go` | Extension | Single Get from Rancher canonical namespace; no test defaults
`DeleteOIDCClient(client, name)` | `extensions/kubeapi/auth/oidcclient/oidcclient.go` | Extension | Generic delete + NotFound idempotency for cleanup paths
`OIDCClientSecretNamespace` const | `extensions/kubeapi/auth/oidcclient/oidcclient.go` | Extension | Rancher canonical namespace (not a test default)
`RancherDeploymentName`, `RancherDeploymentNamespace` consts | `extensions/kubeapi/workloads/deployments/deployments.go` | Extension | Rancher canonical names; sit with the existing deployment helpers rather than in a feature-flag-specific file
`APIClient` + `NewAPIClient(rancherURL)` | `clients/rancher/auth/oidc/oidc.go` | `clients/` | Matches `openldap.NewOLDAP` / `scim.NewClient` pattern — provider client hung off `auth.Client`
`CompleteAuthCodeFlow(...)`, `RawRequest(...)` (methods on `APIClient`) | `clients/rancher/auth/oidc/oidc.go` | `clients/` | Matches `OLDAPClient.Enable()` precedent — multi-step provider workflow as a method on the provider client
`Config` struct, `ConfigurationFileKey`, `OIDCProviderFeatureFlag`, `Default*` consts | `clients/rancher/auth/oidc/config.go` | `clients/` | Matches `openldap.Config` precedent
`Do(client, method, url, body, headers)`, `Response` | `pkg/clientbase/raw.go` | `pkg/` | Lower-level shared utility; replaces SCIM's duplicate private `do`; placed alongside the existing clientbase HTTP helpers per reviewer feedback

## Notes for reviewers

- `IsFeatureEnabled` / `UpdateFeatureFlag` are **not** in this PR — they landed independently on `main` in `a920f45` under `extensions/kubeapi/features`, and the test suite consumes them from there.
- `CreateOIDCClient` deliberately does **not** swallow `AlreadyExists`. The suite generates a random client name per run, so a collision means real leaked state and should fail loudly.
- `Discovery` returns the `*Response` alongside a parse error rather than hard-failing on non-200, so callers can assert on the status code directly.
- Verified end-to-end against a live 2.15 server via rancher/tests#602: 20 tests, all passing.
