### PR TITLE
Add feature flag extensions using wrangler context

### DIFF
--- a/extensions/kubeapi/cluster/cluster.go
+++ b/extensions/kubeapi/cluster/cluster.go
@@ -1,0 +1,24 @@
+package cluster
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/wrangler"
+)
+
+const (
+	LocalCluster = "local"
+)
+
+// GetClusterWranglerContext returns the context for the cluster
+func GetClusterWranglerContext(client *rancher.Client, clusterID string) (*wrangler.Context, error) {
+	if clusterID == LocalCluster {
+		return client.WranglerContext, nil
+	}
+
+	ctx, err := client.WranglerContext.DownStreamClusterWranglerContext(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	return ctx, nil
+}

--- a/extensions/kubeapi/features/features.go
+++ b/extensions/kubeapi/features/features.go
@@ -1,0 +1,40 @@
+package features
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IsFeatureEnabled is a helper function that uses wrangler context to check if a feature is enabled
+func IsFeatureEnabled(client *rancher.Client, featureFlag string) (bool, error) {
+	feature, err := client.WranglerContext.Mgmt.Feature().Get(featureFlag, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	if feature.Spec.Value == nil {
+		return false, nil
+	}
+
+	return *feature.Spec.Value, nil
+}
+
+// UpdateFeatureFlag is a helper function that uses wrangler context to update a feature flag
+func UpdateFeatureFlag(client *rancher.Client, featureFlag string, value bool) error {
+	feature, err := client.WranglerContext.Mgmt.Feature().Get(featureFlag, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if feature.Spec.Value != nil && *feature.Spec.Value == value {
+		return nil
+	}
+
+	feature.Spec.Value = &value
+	_, err = client.WranglerContext.Mgmt.Feature().Update(feature)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/extensions/kubeapi/workloads/deployments/deployments.go
+++ b/extensions/kubeapi/workloads/deployments/deployments.go
@@ -1,0 +1,40 @@
+package deployments
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
+	clusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	RancherDeploymentNamespace = "cattle-system"
+	RancherDeploymentName      = "rancher"
+)
+
+// WaitForDeploymentActive uses wrangler context to wait for a deployment to become active
+func WaitForDeploymentActive(client *rancher.Client, clusterID, namespaceName, deploymentName string) error {
+	wranglerContext, err := clusterapi.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return err
+	}
+
+	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (bool, error) {
+		deployment, err := wranglerContext.Apps.Deployment().Get(namespaceName, deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		desired := *deployment.Spec.Replicas
+
+		if deployment.Status.ReadyReplicas != desired {
+			return false, nil
+		}
+
+		return true, nil
+	},
+	)
+}


### PR DESCRIPTION
This PR adds new extensions to support updating (enabling/disabling), and checking the status of feature flags using the Wrangler context.
- **Feature Flags** (IsFeatureEnabled/UpdateFeatureFlag): Generic CRUD helpers for the Feature resource using Wrangler context.
- **GetClusterWranglerContext**: Generic helper to retrieve a cluster Wrangler context.
- **WaitForDeploymentActive**: Generic helper that waits for a Deployment to become active by polling until replicas are ready. I added this as an extension since wait-based helpers on resources seems to be acceptable as per the guidelines in "Actions vs Extensions" doc? It is useful for scenarios such as feature flag updates where Rancher restarts and we wait for it become active.