### PR TITLE
[Main] Add Namespace kubeapi extensions (wrangler-based)

### DIFF
--- a/extensions/kubeapi/namespaces/create.go
+++ b/extensions/kubeapi/namespaces/create.go
@@ -1,0 +1,22 @@
+package namespaces
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	clusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CreateNamespace creates a namespace in a cluster using wrangler context.
+func CreateNamespace(client *rancher.Client, clusterID string, namespace *corev1.Namespace) (*corev1.Namespace, error) {
+	wranglerCtx, err := clusterapi.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	createdNamespace, err := wranglerCtx.Core.Namespace().Create(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdNamespace, nil
+}

--- a/extensions/kubeapi/namespaces/delete.go
+++ b/extensions/kubeapi/namespaces/delete.go
@@ -1,0 +1,37 @@
+package namespaces
+
+import (
+	"context"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
+	clusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DeleteNamespace deletes a namespace in a cluster using wrangler context
+func DeleteNamespace(client *rancher.Client, clusterID, namespaceName string) error {
+	ctx, err := clusterapi.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return err
+	}
+
+	err = ctx.Core.Namespace().Delete(namespaceName, &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(context.Context) (bool, error) {
+		_, pollErr := ctx.Core.Namespace().Get(namespaceName, metav1.GetOptions{})
+		if pollErr != nil {
+			if k8serrors.IsNotFound(pollErr) {
+				return true, nil
+			}
+			return false, pollErr
+		}
+		return false, nil
+	},
+	)
+}

--- a/extensions/kubeapi/namespaces/list.go
+++ b/extensions/kubeapi/namespaces/list.go
@@ -1,0 +1,23 @@
+package namespaces
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	clusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListNamespaces returns namespaces in a cluster using wrangler context.
+func ListNamespaces(client *rancher.Client, clusterID string, listOpts metav1.ListOptions) (*corev1.NamespaceList, error) {
+	wranglerCtx, err := clusterapi.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceList, err := wranglerCtx.Core.Namespace().List(listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return namespaceList, nil
+}

--- a/extensions/kubeapi/namespaces/namespaces.go
+++ b/extensions/kubeapi/namespaces/namespaces.go
@@ -1,0 +1,18 @@
+package namespaces
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	clusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetNamespaceByName is a helper function that returns the namespace by name in a specific cluster.
+func GetNamespaceByName(client *rancher.Client, clusterID, namespaceName string) (*corev1.Namespace, error) {
+	wranglerCtx, err := clusterapi.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	return wranglerCtx.Core.Namespace().Get(namespaceName, metav1.GetOptions{})
+}

--- a/extensions/kubeapi/namespaces/update.go
+++ b/extensions/kubeapi/namespaces/update.go
@@ -1,0 +1,49 @@
+package namespaces
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
+	clusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+// UpdateNamespace is a helper function that uses wrangler context to update an existing namespace in a cluster
+func UpdateNamespace(client *rancher.Client, clusterID string, updatedNamespace *corev1.Namespace) (*corev1.Namespace, error) {
+	wranglerCtx, err := clusterapi.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	var updated *corev1.Namespace
+	var lastErr error
+	err = kwait.PollUntilContextTimeout(context.TODO(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
+		current, getErr := wranglerCtx.Core.Namespace().Get(updatedNamespace.Name, metav1.GetOptions{})
+		if getErr != nil {
+			lastErr = fmt.Errorf("failed to get Namespace %s: %w", updatedNamespace.Name, getErr)
+			return false, nil
+		}
+
+		updatedNamespace.ResourceVersion = current.ResourceVersion
+		updated, lastErr = wranglerCtx.Core.Namespace().Update(updatedNamespace)
+		if lastErr != nil {
+			if errors.IsConflict(lastErr) {
+				return false, nil
+			}
+			return false, lastErr
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("timed out updating Namespace %s: %w", updatedNamespace.Name, lastErr)
+	}
+
+	return updated, nil
+}


### PR DESCRIPTION
This PR introduces Wrangler-based `namespace` kubeapi helpers so tests can use these instead of dynamic client helpers.

`Note:`
- Having a mix of dynamic client and Wrangler based helpers has caused confusion, especially for new test writers. This PR is part of a broader effort https://github.com/rancher/qa-tasks/issues/2323 to refactor some of the kubeapi helpers to reduce that confusion without impacting any existing tests.
- After this PR is merged, existing namespace helpers in rancher/tests/actions that use the dynamic client (not Steve) will be removed, and any tests using them will be updated to use the new extensions.

