### PR TITLE
Add skipSchemaValidation to catalog APIs

### DIFF
--- a/pkg/api/steve/catalog/types/rest.go
+++ b/pkg/api/steve/catalog/types/rest.go
@@ -40,6 +40,7 @@ type ChartInstallAction struct {
 	Wait                     bool                `json:"wait,omitempty"`
 	DisableHooks             bool                `json:"noHooks,omitempty"`
 	DisableOpenAPIValidation bool                `json:"disableOpenAPIValidation,omitempty"`
+	SkipSchemaValidation     bool                `json:"skipSchemaValidation,omitempty"`
 	Namespace                string              `json:"namespace,omitempty"`
 	ProjectID                string              `json:"projectId,omitempty"`
 	OperationTolerations     []corev1.Toleration `json:"operationTolerations,omitempty"`
@@ -73,6 +74,7 @@ type ChartUpgradeAction struct {
 	Wait                     bool                `json:"wait,omitempty"`
 	DisableHooks             bool                `json:"noHooks,omitempty"`
 	DisableOpenAPIValidation bool                `json:"disableOpenAPIValidation,omitempty"`
+	SkipSchemaValidation     bool                `json:"skipSchemaValidation,omitempty"`
 	Force                    bool                `json:"force,omitempty"`
 	TakeOwnership            bool                `json:"takeOwnership,omitempty"`
 	MaxHistory               int                 `json:"historyMax,omitempty"`


### PR DESCRIPTION
## Issue: rancher/terraform-provider-rancher2#1959
 
## Problem
Adding the SkipValidationSchema field in rancher/rancher#55004 but can't be tested because it is not in Shepherd.
 
## Solution
Update the catalog API with the new fields.
 
## Testing
It adds a new field that is omited by default, so there shouldn't be any issues.

### Regressions Considerations
It adds a new field that is omited by default, so there shouldn't be any issues.