### PR TITLE
tokenregistration: poll with backoff and return error on timeout

### DIFF
--- a/extensions/tokenregistration/tokenregistration.go
+++ b/extensions/tokenregistration/tokenregistration.go
@@ -8,42 +8,20 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/sirupsen/logrus"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
-const (
-	// registrationTokenPollInterval is the interval between polls for a populated
-	// ClusterRegistrationToken.
-	registrationTokenPollInterval = 2 * time.Second
-
-	// registrationTokenPollTimeout is the per-cluster ceiling for waiting on
-	// Rancher to populate ClusterRegistrationToken.Token and .ManifestURL.
-	//
-	// At ~500 downstream clusters we measured token-creation lag of
-	// p50=9s, p95=78s, p99=141s for the default token and p50=113s, p95=249s,
-	// max=315s for the system token. The leader-side cluster-watch handler is
-	// chained behind ~15 other Mgmt.Cluster() handlers, so lag scales with N
-	// — at 999 clusters the tail extends well past the 500-cluster numbers,
-	// so we give 15 minutes of headroom. Tokens that haven't appeared by then
-	// almost always indicate a stuck cluster, not lag.
-	registrationTokenPollTimeout = 15 * time.Minute
-
-	// quietLogThreshold suppresses the "no tokens listed yet" log line until
-	// the poll has been running long enough that absence is actually notable.
-	quietLogThreshold = 60 * time.Second
-)
-
-// GetRegistrationToken polls Rancher for a ClusterRegistrationToken belonging
-// to clusterID and returns the first one whose Token and ManifestURL are both
-// populated. An empty list (or one whose entries have not yet been filled in
-// by Rancher's controllers) is expected during the first ~10-170s of a
-// cluster's life and is not treated as fatal until the overall timeout.
+// GetRegistrationToken polls Rancher for a ClusterRegistrationToken belonging to clusterID
+// and returns the first one whose Token and ManifestURL are both populated, or an error on timeout.
 func GetRegistrationToken(client *rancher.Client, clusterID string) (*management.ClusterRegistrationToken, error) {
 	var populatedToken *management.ClusterRegistrationToken
 	start := time.Now()
+	logrus.Infof("[%s] retrieving cluster registration token", clusterID)
+	lastLog := start
 
-	err := kwait.PollUntilContextTimeout(context.Background(), registrationTokenPollInterval, registrationTokenPollTimeout, true, func(_ context.Context) (done bool, err error) {
+	err := kwait.PollUntilContextTimeout(context.Background(), 2*time.Second, defaults.FifteenMinuteTimeout, true, func(_ context.Context) (done bool, err error) {
 		collection, err := client.Management.ClusterRegistrationToken.ListAll(&types.ListOpts{
 			Filters: map[string]interface{}{
 				"clusterId": clusterID,
@@ -55,8 +33,9 @@ func GetRegistrationToken(client *rancher.Client, clusterID string) (*management
 		}
 
 		if len(collection.Data) == 0 {
-			if time.Since(start) >= quietLogThreshold {
+			if time.Since(lastLog) >= defaults.OneMinuteTimeout {
 				logrus.Warnf("[%s] no cluster registration tokens listed after %s; still waiting", clusterID, time.Since(start).Round(time.Second))
+				lastLog = time.Now()
 			} else {
 				logrus.Debugf("[%s] no cluster registration tokens listed yet", clusterID)
 			}
@@ -71,8 +50,9 @@ func GetRegistrationToken(client *rancher.Client, clusterID string) (*management
 			}
 		}
 
-		if time.Since(start) >= quietLogThreshold {
+		if time.Since(lastLog) >= defaults.OneMinuteTimeout {
 			logrus.Warnf("[%s] %d cluster registration token(s) listed but none populated after %s; still waiting", clusterID, len(collection.Data), time.Since(start).Round(time.Second))
+			lastLog = time.Now()
 		} else {
 			logrus.Debugf("[%s] %d cluster registration token(s) listed but Token/ManifestURL not yet populated", clusterID, len(collection.Data))
 		}
@@ -80,7 +60,7 @@ func GetRegistrationToken(client *rancher.Client, clusterID string) (*management
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("error while retrieving registration token for cluster %s after %s: %w", clusterID, registrationTokenPollTimeout, err)
+		return nil, fmt.Errorf("error while retrieving registration token for cluster %s after %s: %w", clusterID, defaults.FifteenMinuteTimeout, err)
 	}
 
 	logrus.Infof("[%s] cluster registration token populated after %s", clusterID, time.Since(start).Round(time.Second))

--- a/extensions/tokenregistration/tokenregistration.go
+++ b/extensions/tokenregistration/tokenregistration.go
@@ -1,39 +1,88 @@
 package tokenregistration
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/sirupsen/logrus"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
-// GetRegistrationToken is function that gets a specific ClusterRegistrationToken using a Client object with a specified clusterStatusName and token name.
-// It is done using a poll wait to make sure the tokens have been created by rancher.
-func GetRegistrationToken(client *rancher.Client, clusterID string) (*management.ClusterRegistrationToken, error) {
-	var clusterRegistrationTokens []management.ClusterRegistrationToken
+const (
+	// registrationTokenPollInterval is the interval between polls for a populated
+	// ClusterRegistrationToken.
+	registrationTokenPollInterval = 2 * time.Second
 
-	kwait.Poll(500*time.Millisecond, 2*time.Minute, func() (done bool, err error) {
-		collection, err := client.Management.ClusterRegistrationToken.List(&types.ListOpts{
+	// registrationTokenPollTimeout is the per-cluster ceiling for waiting on
+	// Rancher to populate ClusterRegistrationToken.Token and .ManifestURL.
+	//
+	// At ~500 downstream clusters we measured token-creation lag of
+	// p50=9s, p95=78s, p99=141s for the default token and p50=113s, p95=249s,
+	// max=315s for the system token. The leader-side cluster-watch handler is
+	// chained behind ~15 other Mgmt.Cluster() handlers, so lag scales with N
+	// — at 999 clusters the tail extends well past the 500-cluster numbers,
+	// so we give 15 minutes of headroom. Tokens that haven't appeared by then
+	// almost always indicate a stuck cluster, not lag.
+	registrationTokenPollTimeout = 15 * time.Minute
+
+	// quietLogThreshold suppresses the "no tokens listed yet" log line until
+	// the poll has been running long enough that absence is actually notable.
+	quietLogThreshold = 60 * time.Second
+)
+
+// GetRegistrationToken polls Rancher for a ClusterRegistrationToken belonging
+// to clusterID and returns the first one whose Token and ManifestURL are both
+// populated. An empty list (or one whose entries have not yet been filled in
+// by Rancher's controllers) is expected during the first ~10-170s of a
+// cluster's life and is not treated as fatal until the overall timeout.
+func GetRegistrationToken(client *rancher.Client, clusterID string) (*management.ClusterRegistrationToken, error) {
+	var populatedToken *management.ClusterRegistrationToken
+	start := time.Now()
+
+	err := kwait.PollUntilContextTimeout(context.Background(), registrationTokenPollInterval, registrationTokenPollTimeout, true, func(_ context.Context) (done bool, err error) {
+		collection, err := client.Management.ClusterRegistrationToken.ListAll(&types.ListOpts{
 			Filters: map[string]interface{}{
 				"clusterId": clusterID,
 			},
 		})
-
 		if err != nil {
-			return false, err
+			logrus.Errorf("[%s] error while listing cluster registration tokens: %v", clusterID, err)
+			return false, nil
 		}
 
 		if len(collection.Data) == 0 {
-			return false, err
+			if time.Since(start) >= quietLogThreshold {
+				logrus.Warnf("[%s] no cluster registration tokens listed after %s; still waiting", clusterID, time.Since(start).Round(time.Second))
+			} else {
+				logrus.Debugf("[%s] no cluster registration tokens listed yet", clusterID)
+			}
+			return false, nil
 		}
 
-		clusterRegistrationTokens = collection.Data
-		return true, nil
+		for i := range collection.Data {
+			t := &collection.Data[i]
+			if t.Token != "" && t.ManifestURL != "" {
+				populatedToken = t
+				return true, nil
+			}
+		}
+
+		if time.Since(start) >= quietLogThreshold {
+			logrus.Warnf("[%s] %d cluster registration token(s) listed but none populated after %s; still waiting", clusterID, len(collection.Data), time.Since(start).Round(time.Second))
+		} else {
+			logrus.Debugf("[%s] %d cluster registration token(s) listed but Token/ManifestURL not yet populated", clusterID, len(collection.Data))
+		}
+		return false, nil
 	})
 
-	registrationToken := clusterRegistrationTokens[0]
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving registration token for cluster %s after %s: %w", clusterID, registrationTokenPollTimeout, err)
+	}
 
-	return &registrationToken, nil
+	logrus.Infof("[%s] cluster registration token populated after %s", clusterID, time.Since(start).Round(time.Second))
+	return populatedToken, nil
 }


### PR DESCRIPTION
## Issue: 
https://github.com/rancher/shepherd/issues/569
 
## Problem
GetRegistrationToken indexed [0] of the polled-token slice without a length check, causing a panic when the list was empty after timeout. It also returned tokens whose Token/ManifestURL had not yet been populated by Rancher's controllers, so callers using the returned token to register nodes failed with confusing errors. The 2-minute ceiling was too short at scale: p99 token-creation lag is 141s at 500 downstream clusters and extends further at 999.

## Solution
Switch to PollUntilContextTimeout, use ListAll, filter for tokens whose Token AND ManifestURL are both populated, return a wrapped error on timeout, and raise the ceiling to 15 minutes. Add a quiet-log threshold so short happy-path runs stay quiet while long stalls become visible.

GetRegistrationToken now returns a real error instead of a zero-value token; callers that previously ignored err will need to handle it.
 
## Testing

### Regressions Considerations
