### PR TITLE
wait: surface metav1.Status detail from watch.Error events

### DIFF
--- a/pkg/wait/watch.go
+++ b/pkg/wait/watch.go
@@ -2,7 +2,9 @@ package wait
 
 import (
 	"errors"
+	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -37,11 +39,14 @@ func WatchWait(watchInterface watch.Interface, check WatchCheckFunc) error {
 	for {
 		select {
 		case event, open := <-watchInterface.ResultChan():
+			if event.Type == watch.Error {
+				if status, ok := event.Object.(*metav1.Status); ok {
+					return fmt.Errorf("%s: %s (reason=%s code=%d)", WatchConnectionError, status.Message, status.Reason, status.Code)
+				}
+				return fmt.Errorf("%s: unexpected event.Object type %T: %+v", WatchConnectionError, event.Object, event.Object)
+			}
 			if !open {
 				return errors.New(TimeoutError)
-			}
-			if event.Type == watch.Error {
-				return errors.New(WatchConnectionError)
 			}
 
 			done, err := check(event)


### PR DESCRIPTION
## Issue:
https://github.com/rancher/shepherd/issues/570
 
## Problem
WatchWait collapsed every watch.Error to errors.New(WatchConnectionError), discarding the *metav1.Status object that watch typically delivers in event.Object. At scale this forces operators to enable client-side debug logging and re-run to learn whether a failure was Unauthorized, Forbidden, TooManyRequests, ServerTimeout, etc.

## Solution
Type-assert event.Object to *metav1.Status and include Message, Reason, and Code in the returned error. Fall back to a %+v of the unexpected event.Object type if the assertion fails. No public API change.
 
## Testing

### Regressions Considerations
