### PR TITLE
[Backport 2.14] move PodGroupVersionResource to kubeapi package

### DIFF
--- a/extensions/kubeapi/workloads/pods/pods.go
+++ b/extensions/kubeapi/workloads/pods/pods.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -17,6 +18,13 @@ const (
 	PauseImage       = "registry.k8s.io/pause:3.9"
 	DefaultImageName = "nginx"
 )
+
+// PodGroupVersion is the required Group Version for accessing pods in a cluster using the dynamic client.
+var PodGroupVersionResource = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "pods",
+}
 
 // StatusPods is a helper function that uses wrangler context to list pods for a specific cluster with list options.
 func StatusPods(client *rancher.Client, clusterID string, listOpts metav1.ListOptions) ([]string, []error) {

--- a/extensions/workloads/pods/pod_status.go
+++ b/extensions/workloads/pods/pod_status.go
@@ -9,20 +9,12 @@ import (
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/defaults"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
 	PodResourceSteveType = "pod"
 )
-
-// PodGroupVersion is the required Group Version for accessing pods in a cluster using the dynamic client.
-var PodGroupVersionResource = schema.GroupVersionResource{
-	Group:    "",
-	Version:  "v1",
-	Resource: "pods",
-}
 
 // StatusPods is a helper function that uses the steve client to list pods on a namespace for a specific cluster
 // and return the statuses in a list of strings


### PR DESCRIPTION
Backport https://github.com/rancher/shepherd/pull/580