### PR TITLE
Update the summary structure apiserver now returns.

### DIFF
--- a/clients/rancher/v1/client.go
+++ b/clients/rancher/v1/client.go
@@ -57,10 +57,15 @@ type SteveAPIObject struct {
 	Status          any `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
+type SteveSummaryWithBreakdown struct {
+	Total     int            `json:"total"`
+	Namespace map[string]int `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+}
+
 type SteveAPISummaryItem struct {
 	JSONResp map[string]any
-	Property string         `json:"property,omitempty"`
-	Counts   map[string]int `json:"counts,omitempty"`
+	Property string                               `json:"property,omitempty"`
+	Counts   map[string]SteveSummaryWithBreakdown `json:"counts,omitempty"`
 }
 
 // SteveCollection is the collection type of the SteveAPIObjects


### PR DESCRIPTION
Needed to get [#55348](https://github.com/rancher/rancher/pull/55348) to pass

We changed the structure of a returned apiserver type, but while it's shipped in 2.14 it hasn't
been documented and the UI team is supporting this change.

They need it in order to get a summary partitioned by namespaces -- see issue 
[#54935](https://github.com/rancher/rancher/issues/549345) for details.
