### PR TITLE
[main] Cleanup related fixes for tests

### DIFF
--- a/extensions/kubeapi/configmaps/create.go
+++ b/extensions/kubeapi/configmaps/create.go
@@ -20,7 +20,12 @@ func CreateConfigMapWithTemplate(client *rancher.Client, clusterID string, confi
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteConfigMap(client, clusterID, createdConfigMap.Namespace, createdConfigMap.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteConfigMap(adminClient, clusterID, createdConfigMap.Namespace, createdConfigMap.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/configmaps/delete.go
+++ b/extensions/kubeapi/configmaps/delete.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/defaults"
 	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -19,6 +19,9 @@ func DeleteConfigMap(client *rancher.Client, clusterID, namespace, name string, 
 
 	err = clusterContext.Core.ConfigMap().Delete(namespace, name, nil)
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -33,7 +36,7 @@ func DeleteConfigMap(client *rancher.Client, clusterID, namespace, name string, 
 func WaitForConfigMapDeletion(client *rancher.Client, clusterID, namespace, configMapName string) error {
 	return kwait.PollUntilContextTimeout(context.TODO(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
 		_, err = GetConfigMapByName(client, clusterID, namespace, configMapName)
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return true, nil
 		}
 

--- a/extensions/kubeapi/hpa/create.go
+++ b/extensions/kubeapi/hpa/create.go
@@ -29,7 +29,12 @@ func CreateHPA(client *rancher.Client, clusterID string, hpa *autoscalingv2.Hori
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteHPA(client, clusterID, createdHPA.Namespace, createdHPA.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteHPA(adminClient, clusterID, createdHPA.Namespace, createdHPA.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/hpa/delete.go
+++ b/extensions/kubeapi/hpa/delete.go
@@ -21,7 +21,10 @@ func DeleteHPA(client *rancher.Client, clusterID, namespace, name string, waitFo
 
 	err = clusterContext.Autoscaling.HorizontalPodAutoscaler().Delete(namespace, name, &metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to delete HPA: %w", err)
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
 
 	if waitForDeletion {

--- a/extensions/kubeapi/ingresses/create.go
+++ b/extensions/kubeapi/ingresses/create.go
@@ -29,7 +29,12 @@ func CreateIngress(client *rancher.Client, clusterID, ingressName, namespace str
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteIngress(client, clusterID, namespace, createdIngress.Name)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteIngress(adminClient, clusterID, namespace, createdIngress.Name)
 		})
 	}
 

--- a/extensions/kubeapi/ingresses/delete.go
+++ b/extensions/kubeapi/ingresses/delete.go
@@ -3,6 +3,7 @@ package ingresses
 import (
 	"github.com/rancher/shepherd/clients/rancher"
 	clusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,6 +16,9 @@ func DeleteIngress(client *rancher.Client, clusterID, namespace, ingressName str
 
 	err = wranglerCtx.Networking.Ingress().Delete(namespace, ingressName, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/extensions/kubeapi/namespaces/create.go
+++ b/extensions/kubeapi/namespaces/create.go
@@ -20,7 +20,12 @@ func CreateNamespace(client *rancher.Client, clusterID string, namespace *corev1
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteNamespace(client, clusterID, createdNamespace.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteNamespace(adminClient, clusterID, createdNamespace.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/namespaces/delete.go
+++ b/extensions/kubeapi/namespaces/delete.go
@@ -20,6 +20,9 @@ func DeleteNamespace(client *rancher.Client, clusterID, namespaceName string, wa
 
 	err = ctx.Core.Namespace().Delete(namespaceName, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/extensions/kubeapi/projects/create.go
+++ b/extensions/kubeapi/projects/create.go
@@ -1,0 +1,33 @@
+package projects
+
+import (
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/shepherd/clients/rancher"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateProject creates a project using the provided template and wrangler context.
+func CreateProject(client *rancher.Client, clusterID string, projectTemplate *v3.Project) (*v3.Project, error) {
+	createdProject, err := client.WranglerContext.Mgmt.Project().Create(projectTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	if client.Session != nil {
+		client.Session.RegisterCleanupFunc(func() error {
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteProject(adminClient, clusterID, createdProject.Name, true)
+		})
+	}
+
+	return createdProject, nil
+}
+
+// GetProjectByName is a helper function that retrieves a Project from a cluster by name.
+func GetProjectByName(client *rancher.Client, clusterID, projectName string) (*v3.Project, error) {
+	return client.WranglerContext.Mgmt.Project().Get(clusterID, projectName, metav1.GetOptions{})
+}

--- a/extensions/kubeapi/projects/delete.go
+++ b/extensions/kubeapi/projects/delete.go
@@ -1,0 +1,51 @@
+package projects
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DeleteProject is a helper function that uses the wrangler context to delete a Project from a cluster.
+func DeleteProject(client *rancher.Client, clusterID, projectName string, waitForDeletion bool) error {
+	err := client.WranglerContext.Mgmt.Project().Delete(clusterID, projectName, &metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if waitForDeletion {
+		return WaitForProjectDeletion(client, clusterID, projectName)
+	}
+
+	return nil
+}
+
+// WaitForProjectDeletion is a helper function that waits for a Project to be deleted from a cluster.
+func WaitForProjectDeletion(client *rancher.Client, clusterID, projectName string) error {
+	err := kwait.PollUntilContextTimeout(context.TODO(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
+		_, err = GetProjectByName(client, clusterID, projectName)
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+
+		if err != nil {
+			return false, fmt.Errorf("error checking Project deletion status: %w", err)
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("timed out waiting for Project %s to be deleted: %w", projectName, err)
+	}
+
+	return nil
+}

--- a/extensions/kubeapi/projects/update.go
+++ b/extensions/kubeapi/projects/update.go
@@ -1,0 +1,43 @@
+package projects
+
+import (
+	"context"
+	"fmt"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+// UpdateProject is a helper function that uses wrangler context to update an existing project in a cluster
+func UpdateProject(client *rancher.Client, updatedProject *v3.Project) (*v3.Project, error) {
+	var updated *v3.Project
+	var lastErr error
+	err := kwait.PollUntilContextTimeout(context.TODO(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
+		current, getErr := GetProjectByName(client, updatedProject.Namespace, updatedProject.Name)
+		if getErr != nil {
+			lastErr = fmt.Errorf("failed to get Project %s: %w", updatedProject.Name, getErr)
+			return false, nil
+		}
+
+		updatedProject.ResourceVersion = current.ResourceVersion
+		updated, lastErr = client.WranglerContext.Mgmt.Project().Update(updatedProject)
+		if lastErr != nil {
+			if k8serrors.IsConflict(lastErr) {
+				return false, nil
+			}
+			return false, lastErr
+		}
+
+		return true, nil
+	},
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("timed out updating Project %s: %w", updatedProject.Name, lastErr)
+	}
+
+	return updated, nil
+}

--- a/extensions/kubeapi/rbac/create.go
+++ b/extensions/kubeapi/rbac/create.go
@@ -21,7 +21,12 @@ func CreateRole(client *rancher.Client, clusterID string, role *rbacv1.Role) (*r
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteRole(client, clusterID, newRole.Namespace, newRole.Name)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteRole(adminClient, clusterID, newRole.Namespace, newRole.Name)
 		})
 	}
 
@@ -42,7 +47,12 @@ func CreateClusterRole(client *rancher.Client, clusterID string, clusterRole *rb
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteClusterRole(client, clusterID, newClusterRole.Name)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteClusterRole(adminClient, clusterID, newClusterRole.Name)
 		})
 	}
 
@@ -63,7 +73,12 @@ func CreateRoleBinding(client *rancher.Client, clusterID string, roleBinding *rb
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteRoleBinding(client, clusterID, newRoleBinding.Namespace, newRoleBinding.Name)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteRoleBinding(adminClient, clusterID, newRoleBinding.Namespace, newRoleBinding.Name)
 		})
 	}
 
@@ -84,7 +99,12 @@ func CreateClusterRoleBinding(client *rancher.Client, clusterID string, clusterR
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteClusterRoleBinding(client, clusterID, newClusterRoleBinding.Name)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteClusterRoleBinding(adminClient, clusterID, newClusterRoleBinding.Name)
 		})
 	}
 
@@ -105,7 +125,12 @@ func CreateGlobalRole(client *rancher.Client, globalRole *v3.GlobalRole) (*v3.Gl
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteGlobalRole(client, latestGlobalRole.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteGlobalRole(adminClient, latestGlobalRole.Name, true)
 		})
 	}
 
@@ -126,7 +151,12 @@ func CreateGlobalRoleBinding(client *rancher.Client, globalRoleBinding *v3.Globa
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteGlobalRoleBinding(client, latestGlobalRoleBinding.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteGlobalRoleBinding(adminClient, latestGlobalRoleBinding.Name, true)
 		})
 	}
 
@@ -147,7 +177,12 @@ func CreateRoleTemplate(client *rancher.Client, roleTemplate *v3.RoleTemplate) (
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteRoleTemplate(client, latestRoleTemplate.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteRoleTemplate(adminClient, latestRoleTemplate.Name, true)
 		})
 	}
 
@@ -168,7 +203,12 @@ func CreateClusterRoleTemplateBinding(client *rancher.Client, clusterRoleTemplat
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteClusterRoleTemplateBinding(client, latestCRTB.Namespace, latestCRTB.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteClusterRoleTemplateBinding(adminClient, latestCRTB.Namespace, latestCRTB.Name, true)
 		})
 	}
 
@@ -189,7 +229,12 @@ func CreateProjectRoleTemplateBinding(client *rancher.Client, projectRoleTemplat
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteProjectRoleTemplateBinding(client, latestPRTB.Namespace, latestPRTB.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteProjectRoleTemplateBinding(adminClient, latestPRTB.Namespace, latestPRTB.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/rbac/delete.go
+++ b/extensions/kubeapi/rbac/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rancher/shepherd/clients/rancher"
 	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,7 +16,15 @@ func DeleteRole(client *rancher.Client, clusterID, namespace, roleName string) e
 		return err
 	}
 
-	return clusterContext.RBAC.Role().Delete(namespace, roleName, &metav1.DeleteOptions{})
+	err = clusterContext.RBAC.Role().Delete(namespace, roleName, &metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 // DeleteClusterRole deletes a cluster role by name from a specific cluster
@@ -25,7 +34,15 @@ func DeleteClusterRole(client *rancher.Client, clusterID, clusterRoleName string
 		return err
 	}
 
-	return clusterContext.RBAC.ClusterRole().Delete(clusterRoleName, &metav1.DeleteOptions{})
+	err = clusterContext.RBAC.ClusterRole().Delete(clusterRoleName, &metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 // DeleteRoleBinding deletes a role binding by name from a specific cluster
@@ -35,7 +52,15 @@ func DeleteRoleBinding(client *rancher.Client, clusterID, namespace, roleBinding
 		return err
 	}
 
-	return clusterContext.RBAC.RoleBinding().Delete(namespace, roleBindingName, &metav1.DeleteOptions{})
+	err = clusterContext.RBAC.RoleBinding().Delete(namespace, roleBindingName, &metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 // DeleteClusterRoleBinding deletes a cluster role binding by name from a specific cluster
@@ -45,13 +70,24 @@ func DeleteClusterRoleBinding(client *rancher.Client, clusterID, clusterRoleBind
 		return err
 	}
 
-	return clusterContext.RBAC.ClusterRoleBinding().Delete(clusterRoleBindingName, &metav1.DeleteOptions{})
+	err = clusterContext.RBAC.ClusterRoleBinding().Delete(clusterRoleBindingName, &metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 // DeleteGlobalRole deletes a Global Role by name using wrangler context
 func DeleteGlobalRole(client *rancher.Client, globalRoleName string, waitForDelete bool) error {
 	err := client.WranglerContext.Mgmt.GlobalRole().Delete(globalRoleName, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -69,6 +105,9 @@ func DeleteGlobalRole(client *rancher.Client, globalRoleName string, waitForDele
 func DeleteClusterRoleTemplateBinding(client *rancher.Client, crtbNamespace, crtbName string, waitForDelete bool) error {
 	err := client.WranglerContext.Mgmt.ClusterRoleTemplateBinding().Delete(crtbNamespace, crtbName, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -86,6 +125,9 @@ func DeleteClusterRoleTemplateBinding(client *rancher.Client, crtbNamespace, crt
 func DeleteProjectRoleTemplateBinding(client *rancher.Client, prtbNamespace, prtbName string, waitForDelete bool) error {
 	err := client.WranglerContext.Mgmt.ProjectRoleTemplateBinding().Delete(prtbNamespace, prtbName, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -103,7 +145,10 @@ func DeleteProjectRoleTemplateBinding(client *rancher.Client, prtbNamespace, prt
 func DeleteRoleTemplate(client *rancher.Client, roleTemplateName string, waitForDelete bool) error {
 	err := client.WranglerContext.Mgmt.RoleTemplate().Delete(roleTemplateName, nil)
 	if err != nil {
-		return fmt.Errorf("failed to delete role template %s: %w", roleTemplateName, err)
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
 
 	if waitForDelete {
@@ -120,6 +165,10 @@ func DeleteRoleTemplate(client *rancher.Client, roleTemplateName string, waitFor
 func DeleteGlobalRoleBinding(client *rancher.Client, globalRoleBindingName string, waitForDelete bool) error {
 	err := client.WranglerContext.Mgmt.GlobalRoleBinding().Delete(globalRoleBindingName, nil)
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+
 		return fmt.Errorf("failed to delete global role binding %s: %w", globalRoleBindingName, err)
 	}
 

--- a/extensions/kubeapi/secrets/create.go
+++ b/extensions/kubeapi/secrets/create.go
@@ -3,9 +3,8 @@ package secrets
 import (
 	"fmt"
 
-	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
-
 	"github.com/rancher/shepherd/clients/rancher"
+	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -23,7 +22,12 @@ func CreateSecretWithTemplate(client *rancher.Client, clusterID string, secretTe
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteSecret(client, clusterID, createdSecret.Namespace, createdSecret.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteSecret(adminClient, clusterID, createdSecret.Namespace, createdSecret.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/secrets/delete.go
+++ b/extensions/kubeapi/secrets/delete.go
@@ -21,6 +21,9 @@ func DeleteSecret(client *rancher.Client, clusterID, namespaceName, secretName s
 
 	err = clusterContext.Core.Secret().Delete(namespaceName, secretName, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/extensions/kubeapi/services/create.go
+++ b/extensions/kubeapi/services/create.go
@@ -20,7 +20,12 @@ func CreateServiceWithTemplate(client *rancher.Client, clusterID string, service
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteService(client, clusterID, service.Namespace, service.Name)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteService(adminClient, clusterID, service.Namespace, service.Name)
 		})
 	}
 

--- a/extensions/kubeapi/services/delete.go
+++ b/extensions/kubeapi/services/delete.go
@@ -3,6 +3,7 @@ package services
 import (
 	"github.com/rancher/shepherd/clients/rancher"
 	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,6 +16,9 @@ func DeleteService(client *rancher.Client, clusterID, namespace, serviceName str
 
 	err = clusterContext.Core.Service().Delete(namespace, serviceName, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/extensions/kubeapi/users/create.go
+++ b/extensions/kubeapi/users/create.go
@@ -31,7 +31,12 @@ func CreateUser(client *rancher.Client, user *v3.User) (*v3.User, error) {
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteUser(client, createdUser.Username, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteUser(adminClient, createdUser.Username, true)
 		})
 	}
 

--- a/extensions/kubeapi/users/delete.go
+++ b/extensions/kubeapi/users/delete.go
@@ -15,7 +15,10 @@ import (
 func DeleteUser(client *rancher.Client, username string, waitForDelete bool) error {
 	err := client.WranglerContext.Mgmt.User().Delete(username, &metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to delete user %s: %w", username, err)
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
 
 	if waitForDelete {
@@ -31,7 +34,7 @@ func DeleteUser(client *rancher.Client, username string, waitForDelete bool) err
 // WaitForUserDeletion polls until a user with the given name is deleted
 func WaitForUserDeletion(client *rancher.Client, username string) error {
 	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, true, func(ctx context.Context) (bool, error) {
-		_, err := client.WranglerContext.Mgmt.User().Get(username, metav1.GetOptions{})
+		_, err := GetUserByName(client, username)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return true, nil

--- a/extensions/kubeapi/workloads/cronjobs/create.go
+++ b/extensions/kubeapi/workloads/cronjobs/create.go
@@ -29,7 +29,12 @@ func CreateCronJobWithTemplate(client *rancher.Client, clusterID string, cronJob
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteCronJob(client, clusterID, createdCronJob.Namespace, createdCronJob.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteCronJob(adminClient, clusterID, createdCronJob.Namespace, createdCronJob.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/workloads/cronjobs/cronjobs.go
+++ b/extensions/kubeapi/workloads/cronjobs/cronjobs.go
@@ -14,19 +14,16 @@ import (
 
 // WaitForCronJobActive waits until the CronJob has at least one active job using wrangler context and polling.
 func WaitForCronJobActive(client *rancher.Client, clusterID, namespaceName, cronJobName string) error {
-	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
-	if err != nil {
-		return err
-	}
-
 	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (bool, error) {
-		cronJob, err := clusterContext.Batch.CronJob().Get(namespaceName, cronJobName, metav1.GetOptions{})
+		cronJob, err := GetCronJobByName(client, clusterID, namespaceName, cronJobName)
 		if err != nil {
 			return false, nil
 		}
+
 		if len(cronJob.Status.Active) > 0 {
 			return true, nil
 		}
+
 		return false, nil
 	})
 }

--- a/extensions/kubeapi/workloads/cronjobs/delete.go
+++ b/extensions/kubeapi/workloads/cronjobs/delete.go
@@ -21,7 +21,10 @@ func DeleteCronJob(client *rancher.Client, clusterID, cronJobnamespace, cronJobN
 
 	err = clusterContext.Batch.CronJob().Delete(cronJobnamespace, cronJobName, &metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to delete CronJob: %w", err)
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
 
 	if waitForDelete {
@@ -36,20 +39,14 @@ func DeleteCronJob(client *rancher.Client, clusterID, cronJobnamespace, cronJobN
 
 // WaitForCronJobDeletion is a helper to wait for cronjob to delete
 func WaitForCronJobDeletion(client *rancher.Client, clusterID, cronJobNamespace, cronJobName string) error {
-	err := kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
-		_, pollErr = GetCronJobByName(client, clusterID, cronJobNamespace, cronJobName)
-		if pollErr != nil {
-			if k8serrors.IsNotFound(pollErr) {
+	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (done bool, pollErr error) {
+		_, err := GetCronJobByName(client, clusterID, cronJobNamespace, cronJobName)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
-			return false, pollErr
+			return false, err
 		}
 		return false, nil
 	})
-
-	if err != nil {
-		return fmt.Errorf("failed to wait for cronjob to delete: %w", err)
-	}
-
-	return nil
 }

--- a/extensions/kubeapi/workloads/daemonsets/create.go
+++ b/extensions/kubeapi/workloads/daemonsets/create.go
@@ -29,7 +29,12 @@ func CreateDaemonSetWithTemplate(client *rancher.Client, clusterID string, daemo
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteDaemonSet(client, clusterID, createdDaemonset.Namespace, createdDaemonset.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteDaemonSet(adminClient, clusterID, createdDaemonset.Namespace, createdDaemonset.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/workloads/daemonsets/daemonsets.go
+++ b/extensions/kubeapi/workloads/daemonsets/daemonsets.go
@@ -35,7 +35,6 @@ func WaitForDaemonSetReady(client *rancher.Client, clusterID, daemonSetNamespace
 			return false, nil
 		}
 
-		return ds.Status.NumberReady == ds.Status.DesiredNumberScheduled &&
-			ds.Status.UpdatedNumberScheduled == ds.Status.DesiredNumberScheduled, nil
+		return ds.Status.NumberReady == ds.Status.DesiredNumberScheduled, nil
 	})
 }

--- a/extensions/kubeapi/workloads/daemonsets/delete.go
+++ b/extensions/kubeapi/workloads/daemonsets/delete.go
@@ -21,7 +21,10 @@ func DeleteDaemonSet(client *rancher.Client, clusterID, daemonSetNamespace, daem
 
 	err = clusterContext.Apps.DaemonSet().Delete(daemonSetNamespace, daemonSetName, &metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to delete DaemonSet: %w", err)
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
 
 	if waitForDelete {

--- a/extensions/kubeapi/workloads/deployments/create.go
+++ b/extensions/kubeapi/workloads/deployments/create.go
@@ -29,7 +29,12 @@ func CreateDeploymentWithTemplate(client *rancher.Client, clusterID string, depl
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteDeployment(client, clusterID, createdDeployment.Namespace, createdDeployment.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteDeployment(adminClient, clusterID, createdDeployment.Namespace, createdDeployment.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/workloads/deployments/delete.go
+++ b/extensions/kubeapi/workloads/deployments/delete.go
@@ -20,6 +20,9 @@ func DeleteDeployment(client *rancher.Client, clusterID, namespace, deploymentNa
 
 	err = clusterContext.Apps.Deployment().Delete(namespace, deploymentName, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/extensions/kubeapi/workloads/deployments/deployments.go
+++ b/extensions/kubeapi/workloads/deployments/deployments.go
@@ -34,13 +34,13 @@ func WaitForDeploymentActive(client *rancher.Client, clusterID, deploymentNamesp
 		if err != nil {
 			return false, nil
 		}
+
 		if deployment.Spec.Replicas == nil {
 			return false, nil
 		}
 
 		desired := *deployment.Spec.Replicas
 		return deployment.Status.UpdatedReplicas == desired &&
-			deployment.Status.ReadyReplicas == desired &&
 			deployment.Status.AvailableReplicas == desired &&
 			deployment.Status.Replicas == desired, nil
 	})

--- a/extensions/kubeapi/workloads/jobs/create.go
+++ b/extensions/kubeapi/workloads/jobs/create.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CreateJobWithTemplate creates a Job in a cluster using the provided template and wrangler context.
-func CreateJobWithTemplate(client *rancher.Client, clusterID string, jobTemplate *batchv1.Job, waitForComplete bool) (*batchv1.Job, error) {
+func CreateJobWithTemplate(client *rancher.Client, clusterID string, jobTemplate *batchv1.Job, waitForActive bool) (*batchv1.Job, error) {
 	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster context: %w", err)
@@ -20,16 +20,21 @@ func CreateJobWithTemplate(client *rancher.Client, clusterID string, jobTemplate
 		return nil, fmt.Errorf("failed to create Job: %w", err)
 	}
 
-	if waitForComplete {
-		err = WaitForJobComplete(client, clusterID, createdJob.Namespace, createdJob.Name)
+	if waitForActive {
+		err = WaitForJobActive(client, clusterID, createdJob.Namespace, createdJob.Name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to wait for job completion: %w", err)
+			return nil, fmt.Errorf("failed to wait for job to become active: %w", err)
 		}
 	}
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteJob(client, clusterID, createdJob.Namespace, createdJob.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteJob(adminClient, clusterID, createdJob.Namespace, createdJob.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/workloads/jobs/delete.go
+++ b/extensions/kubeapi/workloads/jobs/delete.go
@@ -18,8 +18,12 @@ func DeleteJob(client *rancher.Client, clusterID, jobNamespace, jobName string, 
 		return err
 	}
 
-	err = clusterContext.Batch.Job().Delete(jobNamespace, jobName, &metav1.DeleteOptions{})
+	propagationPolicy := metav1.DeletePropagationBackground
+	err = clusterContext.Batch.Job().Delete(jobNamespace, jobName, &metav1.DeleteOptions{PropagationPolicy: &propagationPolicy})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -32,13 +36,8 @@ func DeleteJob(client *rancher.Client, clusterID, jobNamespace, jobName string, 
 
 // WaitForJobDeleted waits until the specified Job is deleted from the cluster.
 func WaitForJobDeleted(client *rancher.Client, clusterID, jobNamespace, jobName string) error {
-	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
-	if err != nil {
-		return err
-	}
-
 	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (bool, error) {
-		_, err := clusterContext.Batch.Job().Get(jobNamespace, jobName, metav1.GetOptions{})
+		_, err := GetJobByName(client, clusterID, jobNamespace, jobName)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return true, nil

--- a/extensions/kubeapi/workloads/jobs/jobs.go
+++ b/extensions/kubeapi/workloads/jobs/jobs.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults"
 	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
@@ -28,24 +27,18 @@ func GetJobByName(client *rancher.Client, clusterID, jobNamespace, jobName strin
 	return job, nil
 }
 
-// WaitForJobComplete waits until the Job is complete using wrangler context and polling.
-func WaitForJobComplete(client *rancher.Client, clusterID, jobNamespace, jobName string) error {
-	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
-	if err != nil {
-		return err
-	}
-
+// WaitForJobActive waits until the Job is active using wrangler context and polling.
+func WaitForJobActive(client *rancher.Client, clusterID, jobNamespace, jobName string) error {
 	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (bool, error) {
-		job, err := clusterContext.Batch.Job().Get(jobNamespace, jobName, metav1.GetOptions{})
+		job, err := GetJobByName(client, clusterID, jobNamespace, jobName)
 		if err != nil {
 			return false, nil
 		}
 
-		for _, c := range job.Status.Conditions {
-			if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
-				return true, nil
-			}
+		if job.Status.Active == 1 {
+			return true, nil
 		}
+
 		return false, nil
 	})
 }

--- a/extensions/kubeapi/workloads/jobs/update.go
+++ b/extensions/kubeapi/workloads/jobs/update.go
@@ -9,12 +9,11 @@ import (
 	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 // UpdateJob updates an existing Job using wrangler context
-func UpdateJob(client *rancher.Client, clusterID string, updatedJob *batchv1.Job, waitForCompletion bool) (*batchv1.Job, error) {
+func UpdateJob(client *rancher.Client, clusterID string, updatedJob *batchv1.Job, waitForActive bool) (*batchv1.Job, error) {
 	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster context: %w", err)
@@ -24,7 +23,7 @@ func UpdateJob(client *rancher.Client, clusterID string, updatedJob *batchv1.Job
 	var lastErr error
 
 	err = kwait.PollUntilContextTimeout(context.TODO(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (bool, error) {
-		current, getErr := clusterContext.Batch.Job().Get(updatedJob.Namespace, updatedJob.Name, metav1.GetOptions{})
+		current, getErr := GetJobByName(client, clusterID, updatedJob.Namespace, updatedJob.Name)
 		if getErr != nil {
 			lastErr = fmt.Errorf("failed to get Job %s/%s: %w", updatedJob.Namespace, updatedJob.Name, getErr)
 			return false, nil
@@ -44,8 +43,8 @@ func UpdateJob(client *rancher.Client, clusterID string, updatedJob *batchv1.Job
 		return nil, fmt.Errorf("timed out updating Job %s/%s: %w", updatedJob.Namespace, updatedJob.Name, lastErr)
 	}
 
-	if waitForCompletion {
-		err = WaitForJobComplete(client, clusterID, updated.Namespace, updated.Name)
+	if waitForActive {
+		err = WaitForJobActive(client, clusterID, updated.Namespace, updated.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/extensions/kubeapi/workloads/pods/create.go
+++ b/extensions/kubeapi/workloads/pods/create.go
@@ -29,7 +29,12 @@ func CreatePodWithTemplate(client *rancher.Client, clusterID string, podTemplate
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeletePod(client, clusterID, createdPod.Namespace, createdPod.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeletePod(adminClient, clusterID, createdPod.Namespace, createdPod.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/workloads/pods/delete.go
+++ b/extensions/kubeapi/workloads/pods/delete.go
@@ -21,6 +21,9 @@ func DeletePod(client *rancher.Client, clusterID, namespace, podName string, wai
 
 	err = clusterContext.Core.Pod().Delete(namespace, podName, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -36,13 +39,8 @@ func DeletePod(client *rancher.Client, clusterID, namespace, podName string, wai
 
 // WaitForPodDeleted waits until the specified pod is deleted from the cluster
 func WaitForPodDeleted(client *rancher.Client, clusterID, namespace, podName string) error {
-	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
-	if err != nil {
-		return err
-	}
-
 	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(context.Context) (bool, error) {
-		_, err := clusterContext.Core.Pod().Get(namespace, podName, metav1.GetOptions{})
+		_, err := GetPodByName(client, clusterID, namespace, podName)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return true, nil

--- a/extensions/kubeapi/workloads/pods/pods.go
+++ b/extensions/kubeapi/workloads/pods/pods.go
@@ -55,13 +55,8 @@ func StatusPods(client *rancher.Client, clusterID string, listOpts metav1.ListOp
 
 // WaitForPodRunning waits until the specified pod reaches the Running state
 func WaitForPodRunning(client *rancher.Client, clusterID, podNamespace, podName string) error {
-	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
-	if err != nil {
-		return err
-	}
-
 	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(context.Context) (bool, error) {
-		pod, err := clusterContext.Core.Pod().Get(podNamespace, podName, metav1.GetOptions{})
+		pod, err := GetPodByName(client, clusterID, podNamespace, podName)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return false, nil

--- a/extensions/kubeapi/workloads/statefulsets/create.go
+++ b/extensions/kubeapi/workloads/statefulsets/create.go
@@ -29,7 +29,12 @@ func CreateStatefulSetWithTemplate(client *rancher.Client, clusterID string, ssT
 
 	if client.Session != nil {
 		client.Session.RegisterCleanupFunc(func() error {
-			return DeleteStatefulSet(client, clusterID, createdSS.Namespace, createdSS.Name, true)
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				return err
+			}
+
+			return DeleteStatefulSet(adminClient, clusterID, createdSS.Namespace, createdSS.Name, true)
 		})
 	}
 

--- a/extensions/kubeapi/workloads/statefulsets/delete.go
+++ b/extensions/kubeapi/workloads/statefulsets/delete.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/defaults"
 	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
@@ -21,6 +21,9 @@ func DeleteStatefulSet(client *rancher.Client, clusterID, namespace, name string
 
 	err = clusterContext.Apps.StatefulSet().Delete(namespace, name, &metav1.DeleteOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -36,15 +39,10 @@ func DeleteStatefulSet(client *rancher.Client, clusterID, namespace, name string
 
 // WaitForStatefulSetDeleted waits until the specified StatefulSet is deleted from the cluster.
 func WaitForStatefulSetDeleted(client *rancher.Client, clusterID, namespace, name string) error {
-	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
-	if err != nil {
-		return err
-	}
-
 	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.OneMinuteTimeout, false, func(ctx context.Context) (bool, error) {
-		_, err := clusterContext.Apps.StatefulSet().Get(namespace, name, metav1.GetOptions{})
+		_, err := GetStatefulSetByName(client, clusterID, namespace, name)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
 			return false, err

--- a/extensions/kubeapi/workloads/statefulsets/statefulsets.go
+++ b/extensions/kubeapi/workloads/statefulsets/statefulsets.go
@@ -29,13 +29,8 @@ func GetStatefulSetByName(client *rancher.Client, clusterID, statefulSetNamespac
 
 // WaitForStatefulSetReady waits until the StatefulSet has all ready replicas using wrangler context and polling.
 func WaitForStatefulSetReady(client *rancher.Client, clusterID, statefulSetNamespace, statefulSetName string) error {
-	clusterContext, err := extclusterapi.GetClusterWranglerContext(client, clusterID)
-	if err != nil {
-		return err
-	}
-
 	return kwait.PollUntilContextTimeout(context.Background(), defaults.FiveSecondTimeout, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (bool, error) {
-		ss, err := clusterContext.Apps.StatefulSet().Get(statefulSetNamespace, statefulSetName, metav1.GetOptions{})
+		ss, err := GetStatefulSetByName(client, clusterID, statefulSetNamespace, statefulSetName)
 		if err != nil {
 			return false, nil
 		}

--- a/pkg/wrangler/pkg/generic/controller.go
+++ b/pkg/wrangler/pkg/generic/controller.go
@@ -284,21 +284,29 @@ func (c *Controller[T, TList]) Cache() CacheInterface[T] {
 func (c *Controller[T, TList]) Create(obj T) (T, error) {
 	result := reflect.New(c.objType).Interface().(T)
 
+	if err := c.embeddedClient.Create(context.TODO(), obj.GetNamespace(), obj, result, metav1.CreateOptions{}); err != nil {
+		return result, err
+	}
+
+	namespace := result.GetNamespace()
+	name := result.GetName()
+
 	c.ts.RegisterCleanupFunc(func() error {
-		err := c.embeddedClient.Delete(context.TODO(), obj.GetNamespace(), obj.GetName(), metav1.DeleteOptions{})
-		if errors.IsNotFound(err) {
+		err := c.embeddedClient.Delete(context.TODO(), namespace, name, metav1.DeleteOptions{})
+		if errors.IsNotFound(err) || errors.IsForbidden(err) {
 			return nil
 		}
-		name := obj.GetName()
-		if obj.GetNamespace() != "" {
-			name = obj.GetNamespace() + "/" + name
+
+		displayName := name
+		if namespace != "" {
+			displayName = namespace + "/" + name
 		}
 		gvk := obj.GetObjectKind().GroupVersionKind()
 
-		return fmt.Errorf("unable to delete (%v) %v: %w", gvk, name, err)
+		return fmt.Errorf("unable to delete (%v) %v: %w", gvk, displayName, err)
 	})
 
-	return result, c.embeddedClient.Create(context.TODO(), obj.GetNamespace(), obj, result, metav1.CreateOptions{})
+	return result, nil
 }
 
 // Update updates the object and return the newly updated Object or an error.


### PR DESCRIPTION
We have been seeing recurring resource-cleanup failures at test teardown.  Upon triaging, this required two changes. 
- **Extensions** - clean up with an admin client (not the creating client): 
    - **Problem**: RBAC tests create resources as a specific user. The controller auto-registers a cleanup that deletes the resource using the same client that created it. But create permission does not imply delete permission, so at teardown the user-scoped delete fails:
`Cleanup error: unable to delete (/, Kind=) c-m-kb2r4jjq/auto-testproject-gkjjc:
projects.management.cattle.io "auto-testproject-gkjjc" is forbidden:
		User "u-8wbx2" cannot delete resource "projects" in API group "management.cattle.io"`

    - **Change**: Explicitly register an admin-scoped cleanup
    
- **pkg/wrangler/pkg/generic/controller.go** - fix auto-cleanup for GenerateName resources  
    - **Problem**: Controller.Create captured the name/namespace for its auto-cleanup from the input object. For resources created with metav1.GenerateName, the input object's Name is empty, the real name is only assigned on creation. The cleanup therefore issued a delete with an empty name:
`		Cleanup error: unable to delete (/, Kind=) c-m-kb2r4jjq/: resource name may not be empty`
    - **Change**: Reordered Create so the object is created first, then the cleanup is registered. Auto-registered cleanup now targets the correct resource for both explicitly-named and GenerateName resources, eliminating the "resource name may not be empty" teardown errors.

**QA Task**: https://github.com/rancher/qa-tasks/issues/2323