### PR TITLE
Surface kubectl job failures instead of masking them

### DIFF
--- a/extensions/kubectl/command.go
+++ b/extensions/kubectl/command.go
@@ -3,7 +3,6 @@ package kubectl
 import (
 	"errors"
 	"fmt"
-	"net"
 	"strings"
 
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
@@ -91,10 +90,15 @@ func Command(client *rancher.Client, yamlContent *management.ImportClusterYamlIn
 
 	jobTemplate.Spec.Template.Spec.Containers = append(jobTemplate.Spec.Template.Spec.Containers, container)
 	jobTemplate.Spec.Template.Spec.Volumes = volumes
-	err = CreateJobAndRunKubectlCommands(clusterID, jobName, jobTemplate, client)
-	if err, ok := err.(net.Error); ok && !err.Timeout() {
-		return "", err
-	}
+	// Run the kubectl job. The error is captured but not returned immediately:
+	// the job pod's logs are fetched below as a best effort because they usually
+	// explain why a job failed (e.g. image pull errors or command output). If the
+	// logs cannot be retrieved, the job error is surfaced so the real cause is not
+	// hidden. Previously only non-timeout net.Error failures were returned; the
+	// watch timeout returned by wait.WatchWait (a plain error) was silently
+	// discarded, and when no pod could be found GetPodLogs failed with a
+	// misleading "resource name may not be empty".
+	jobErr := CreateJobAndRunKubectlCommands(clusterID, jobName, jobTemplate, client)
 
 	steveClient, err := client.Steve.ProxyDownstream(clusterID)
 	if err != nil {
@@ -113,8 +117,19 @@ func Command(client *rancher.Client, yamlContent *management.ImportClusterYamlIn
 			break
 		}
 	}
+
+	if podName == "" {
+		if jobErr != nil {
+			return "", fmt.Errorf("kubectl job %s did not produce a pod in namespace %s; job error: %w", jobName, Namespace, jobErr)
+		}
+		return "", fmt.Errorf("kubectl job %s did not produce a pod in namespace %s", jobName, Namespace)
+	}
+
 	podLogs, err := kubeconfig.GetPodLogs(client, clusterID, podName, Namespace, logBufferSize)
 	if err != nil {
+		if jobErr != nil {
+			return "", fmt.Errorf("kubectl job %s failed (job error: %w); failed to stream logs for pod %s/%s: %v", jobName, jobErr, Namespace, podName, err)
+		}
 		return "", err
 	}
 

--- a/extensions/kubectl/command.go
+++ b/extensions/kubectl/command.go
@@ -17,9 +17,34 @@ import (
 
 const volumeName = "config"
 
-// Command runs the given command on a pod in the target cluster via the Rancher Management API.
-// If yamlContent is provided, an init container seeds a config file from it. Returns the job's
-// logs on success, or an error (e.g. empty command, bad logBufferSize) otherwise.
+// Command executes the given command on a pod inside the target downstream cluster and returns
+// the pod's logs. It runs the command through Rancher's "shell-image" container, which has
+// kubectl available and a kubeconfig mounted at /root/.kube, so the command executes against
+// the target cluster as a cluster-admin.
+//
+// The pod is created by submitting a Kubernetes Job (see CreateJobAndRunKubectlCommands), which
+// also provisions a throwaway ServiceAccount bound to the cluster-admin role. The function then
+// locates the resulting pod by the random suffix appended to the job name and streams its logs.
+//
+// When yamlContent is non-nil, an init container seeds /config/my-pod.yaml with the provided YAML
+// before the main container runs. This is useful for feeding a manifest into the command.
+//
+// Parameters:
+//   - client: the rancher.Client used to talk to the Rancher Management API and proxy the
+//     downstream cluster.
+//   - yamlContent: optional *management.ImportClusterYamlInput whose YAML is written to the
+//     container filesystem via an init container. Pass nil to skip the init container.
+//   - clusterID: the ID of the target cluster the command runs against.
+//   - command: the command to execute, as an argv-style slice (e.g. []string{"kubectl", "get", "pods"}).
+//     Must be non-empty; an empty slice returns an error.
+//   - logBufferSize: the size of the buffer used when streaming the pod logs, as a size string
+//     (e.g. "64KB", "8MB"). An invalid format is forwarded to the log streamer and may surface
+//     as an error.
+//
+// Returns the pod's log output as a string, or an error if the command is empty, the job or pod
+// cannot be created/located, or the logs cannot be streamed. When the underlying job fails, the
+// function still attempts to fetch logs because they usually reveal the real cause; the job error
+// is wrapped into the returned error only if the logs cannot be retrieved.
 func Command(client *rancher.Client, yamlContent *management.ImportClusterYamlInput, clusterID string, command []string, logBufferSize string) (string, error) {
 
 	if len(command) == 0 {

--- a/extensions/kubectl/command.go
+++ b/extensions/kubectl/command.go
@@ -17,23 +17,9 @@ import (
 
 const volumeName = "config"
 
-// Command executes a given command on a Kubernetes pod within a specified cluster using the Rancher Management API and kubectl.
-// It optionally sets up an init container to populate a configuration file if yamlContent is provided. The function returns
-// the job's logs upon completion. The clusterID identifies the target cluster, and command specifies the command to execute,
-// which must not be empty. The logBufferSize defines the size for log output buffering (e.g., "64KB", "8MB", "1GB");
-// if empty, the default size is used. An invalid logBufferSize format returns an error. The function returns "StatusOK"
-// and the execution logs if successful, or an error detailing the failure.
-//
-// Parameters:
-// - client: Pointer to a rancher.Client used to interact with the Rancher Management API.
-// - yamlContent: Optional *management.ImportClusterYamlInput to set up an init container for configuration. If nil, no init container is set up.
-// - clusterID: String identifying the target cluster.
-// - command: Slice of strings representing the command to execute. Must not be empty.
-// - logBufferSize: String representing the log buffer size (e.g., "64KB"). If empty, defaults to the system default size.
-//
-// Returns:
-// - A string containing the logs of the executed job.
-// - An error if the command is empty, if there is an issue with setting up the job, or if log retrieval fails.
+// Command runs the given command on a pod in the target cluster via the Rancher Management API.
+// If yamlContent is provided, an init container seeds a config file from it. Returns the job's
+// logs on success, or an error (e.g. empty command, bad logBufferSize) otherwise.
 func Command(client *rancher.Client, yamlContent *management.ImportClusterYamlInput, clusterID string, command []string, logBufferSize string) (string, error) {
 
 	if len(command) == 0 {
@@ -90,14 +76,8 @@ func Command(client *rancher.Client, yamlContent *management.ImportClusterYamlIn
 
 	jobTemplate.Spec.Template.Spec.Containers = append(jobTemplate.Spec.Template.Spec.Containers, container)
 	jobTemplate.Spec.Template.Spec.Volumes = volumes
-	// Run the kubectl job. The error is captured but not returned immediately:
-	// the job pod's logs are fetched below as a best effort because they usually
-	// explain why a job failed (e.g. image pull errors or command output). If the
-	// logs cannot be retrieved, the job error is surfaced so the real cause is not
-	// hidden. Previously only non-timeout net.Error failures were returned; the
-	// watch timeout returned by wait.WatchWait (a plain error) was silently
-	// discarded, and when no pod could be found GetPodLogs failed with a
-	// misleading "resource name may not be empty".
+	// Capture the job error but still try to fetch logs below — they usually reveal
+	// the real cause. Only surface jobErr if logs can't be retrieved.
 	jobErr := CreateJobAndRunKubectlCommands(clusterID, jobName, jobTemplate, client)
 
 	steveClient, err := client.Steve.ProxyDownstream(clusterID)


### PR DESCRIPTION
## Problem
`kubectl.Command()` masked the real cause of helper-Job failures. It only re-surfaced non-timeout `net.Error`s from `CreateJobAndRunKubectlCommands`; the watch timeout from `wait.WatchWait` (a plain error) and other non-`net.Error` failures were silently discarded. It then proceeded to fetch the job pod's logs, and when no pod matched, `GetPodLogs("")` failed with a misleading **`resource name may not be empty`** — hiding the actual root cause (e.g. an unpullable `shell-image` in an airgap cluster).

## Fix
- Capture the job error as `jobErr` instead of swallowing it, while **preserving** the best-effort log fetch (pod logs usually explain the failure).
- Guard the empty-`podName` case with a clear error that includes `jobErr`.
- Augment the log-stream failure with `jobErr` when the job also failed.
- Behavior is unchanged when logs are retrievable — still returns `(logs, nil)`.

## Verification
Reproduced the failure condition (unpullable `shell-image`) against a live cluster via `rancher/tests`:
- **Before:** `error streaming pod logs for pod kube-system/: resource name may not be empty`
- **After:** `kubectl job kubectl-hrglgn failed (job error: error with watch connection…); … container … is waiting to start: image can't be pulled`

`gofmt` clean; `go vet` / `go build ./extensions/kubectl/` pass.