### PR TITLE
Modify UpdateUser user extension to pass principalID

### DIFF
--- a/extensions/kubeapi/users/update.go
+++ b/extensions/kubeapi/users/update.go
@@ -29,6 +29,10 @@ func UpdateUser(client *rancher.Client, user *v3.User) (*v3.User, error) {
 			return false, nil
 		}
 		user.ResourceVersion = current.ResourceVersion
+		// If the provided user object doesn't have PrincipalIds populated, inherit them from the current state to satisfy the admission webhook.
+		if len(user.PrincipalIDs) == 0 {
+			user.PrincipalIDs = current.PrincipalIDs
+		}
 		updated, lastErr = client.WranglerContext.Mgmt.User().Update(user)
 		if lastErr != nil {
 			if k8serrors.IsConflict(lastErr) {


### PR DESCRIPTION
Previously you could update a user object without strictly preserving the `principalIDs` array, or you could pass null, and the API would tolerate it.

With the addition of https://github.com/rancher/webhook/pull/1772,  the webhook actively blocks any update that alters or removes a user's `principalID`. Since the GO client payload sent for the update omits the `principalID` it ends up being serialized to `null` and the webhook fails due to trying to update an immutable field.

This PR grabs the user's current `principalID` and injects it into the user object before updating the user in order to adhere to the webhook changes.